### PR TITLE
Add AWS Inf2 instances support for aws_batch scheduler

### DIFF
--- a/torchx/specs/named_resources_aws.py
+++ b/torchx/specs/named_resources_aws.py
@@ -354,6 +354,46 @@ def aws_trn1_32xlarge() -> Resource:
     )
 
 
+def aws_inf2_xlarge() -> Resource:
+    return Resource(
+        cpu=4,
+        gpu=0,
+        memMB=16 * GiB,
+        capabilities={K8S_ITYPE: "inf2.xlarge"},
+        devices={NEURON_DEVICE: 1},
+    )
+
+
+def aws_inf2_8xlarge() -> Resource:
+    return Resource(
+        cpu=32,
+        gpu=0,
+        memMB=128 * GiB,
+        capabilities={K8S_ITYPE: "inf2.8xlarge"},
+        devices={NEURON_DEVICE: 1},
+    )
+
+
+def aws_inf2_24xlarge() -> Resource:
+    return Resource(
+        cpu=96,
+        gpu=0,
+        memMB=384 * GiB,
+        capabilities={K8S_ITYPE: "inf2.24xlarge"},
+        devices={NEURON_DEVICE: 6},
+    )
+
+
+def aws_inf2_48xlarge() -> Resource:
+    return Resource(
+        cpu=192,
+        gpu=0,
+        memMB=768 * GiB,
+        capabilities={K8S_ITYPE: "inf2.48xlarge"},
+        devices={NEURON_DEVICE: 12},
+    )
+
+
 NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_t3.medium": aws_t3_medium,
     "aws_m5.2xlarge": aws_m5_2xlarge,
@@ -390,4 +430,8 @@ NAMED_RESOURCES: Mapping[str, Callable[[], Resource]] = {
     "aws_g6e.48xlarge": aws_g6e_48xlarge,
     "aws_trn1.2xlarge": aws_trn1_2xlarge,
     "aws_trn1.32xlarge": aws_trn1_32xlarge,
+    "aws_inf2.xlarge": aws_inf2_xlarge,
+    "aws_inf2.8xlarge": aws_inf2_8xlarge,
+    "aws_inf2.24xlarge": aws_inf2_24xlarge,
+    "aws_inf2.48xlarge": aws_inf2_48xlarge,
 }

--- a/torchx/specs/test/named_resources_aws_test.py
+++ b/torchx/specs/test/named_resources_aws_test.py
@@ -32,6 +32,10 @@ from torchx.specs.named_resources_aws import (
     aws_g6e_4xlarge,
     aws_g6e_8xlarge,
     aws_g6e_xlarge,
+    aws_inf2_24xlarge,
+    aws_inf2_48xlarge,
+    aws_inf2_8xlarge,
+    aws_inf2_xlarge,
     aws_m5_2xlarge,
     aws_p3_16xlarge,
     aws_p3_2xlarge,
@@ -231,6 +235,31 @@ class NamedResourcesTest(unittest.TestCase):
         self.assertEqual(trn1_32.gpu, trn1_2.gpu)
         self.assertEqual(trn1_32.memMB, trn1_2.memMB * 16)
         self.assertEqual({EFA_DEVICE: 8, NEURON_DEVICE: 16}, trn1_32.devices)
+
+    def test_aws_inf2(self) -> None:
+        inf2_1 = aws_inf2_xlarge()
+        self.assertEqual(4, inf2_1.cpu)
+        self.assertEqual(0, inf2_1.gpu)
+        self.assertEqual(16 * GiB, inf2_1.memMB)
+        self.assertEqual({NEURON_DEVICE: 1}, inf2_1.devices)
+
+        inf2_8 = aws_inf2_8xlarge()
+        self.assertEqual(32, inf2_8.cpu)
+        self.assertEqual(0, inf2_8.gpu)
+        self.assertEqual(128 * GiB, inf2_8.memMB)
+        self.assertEqual({NEURON_DEVICE: 1}, inf2_8.devices)
+
+        inf2_24 = aws_inf2_24xlarge()
+        self.assertEqual(96, inf2_24.cpu)
+        self.assertEqual(0, inf2_24.gpu)
+        self.assertEqual(384 * GiB, inf2_24.memMB)
+        self.assertEqual({NEURON_DEVICE: 6}, inf2_24.devices)
+
+        inf2_48 = aws_inf2_48xlarge()
+        self.assertEqual(192, inf2_48.cpu)
+        self.assertEqual(0, inf2_48.gpu)
+        self.assertEqual(768 * GiB, inf2_48.memMB)
+        self.assertEqual({NEURON_DEVICE: 12}, inf2_48.devices)
 
     def test_aws_m5_2xlarge(self) -> None:
         resource = aws_m5_2xlarge()


### PR DESCRIPTION
Add AWS Inf2 instances support for aws_batch scheduler. There're usecases to use torchx to launch data parallel inference jobs on inf2 instances on AWS Batch.

Configurations are referencing https://aws.amazon.com/ec2/instance-types/inf2/

Test plan:
Updated unittest to cover new changes.
```
671 passed, 98 warnings in 177.52s (0:02:57)
```

```
❯ torchx run -s local_docker --dryrun dist.ddp -h aws_inf2.48xlarge -j 1 --m abc
```
=== SCHEDULER REQUEST ===
- !!python/object:torchx.schedulers.docker_scheduler.DockerContainer
  command:
  - bash
  - -c
  - torchrun --rdzv_backend c10d --rdzv_endpoint localhost:0 --rdzv_id 'abc-kr12qr37093rz'
    --nnodes 1 --nproc_per_node 1 --tee 3 --role '' -m abc
  image: sha256:3f8f845e25030d9523bf299dee1c3ca6f2b008fc2bf0a2161ed949efe168a3e1
  kwargs:
    devices:
    - /dev/neuron0:/dev/neuron0:rwm
    - /dev/neuron1:/dev/neuron1:rwm
    - /dev/neuron2:/dev/neuron2:rwm
    - /dev/neuron3:/dev/neuron3:rwm
    - /dev/neuron4:/dev/neuron4:rwm
    - /dev/neuron5:/dev/neuron5:rwm
    - /dev/neuron6:/dev/neuron6:rwm
    - /dev/neuron7:/dev/neuron7:rwm
    - /dev/neuron8:/dev/neuron8:rwm
    - /dev/neuron9:/dev/neuron9:rwm
    - /dev/neuron10:/dev/neuron10:rwm
    - /dev/neuron11:/dev/neuron11:rwm
    environment:
      LOGLEVEL: WARNING
      TORCHX_JOB_ID: local_docker://torchx/abc-kr12qr37093rz
      TORCHX_RANK0_HOST: abc-kr12qr37093rz-abc-0
      TORCHX_TRACKING_EXPERIMENT_NAME: default-experiment
    hostname: abc-kr12qr37093rz-abc-0
    labels:
      torchx.pytorch.org/app-id: abc-kr12qr37093rz
      torchx.pytorch.org/replica-id: '0'
      torchx.pytorch.org/role-name: abc
      torchx.pytorch.org/version: 0.8.0dev0
    mem_limit: 377472m
    mounts: []
    name: abc-kr12qr37093rz-abc-0
    nano_cpus: 192000000000
    network: torchx
    privileged: false
    shm_size: 377472m
```