### PR TITLE
Make it possible for users to disable .torchxconfig

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -494,6 +494,8 @@ def find_configs(dirs: Optional[Iterable[str]] = None) -> List[str]:
 
     config = os.getenv(ENV_TORCHXCONFIG)
     if config is not None:
+        if not config:
+            return []
         configfile = Path(config)
         if not configfile.is_file():
             raise FileNotFoundError(

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -275,6 +275,12 @@ class ConfigTest(TestWithTmpDir):
             ),
         )
 
+    def test_no_config(self) -> None:
+        config_dir = self.tmpdir
+        with patch.dict(os.environ, {ENV_TORCHXCONFIG: str("")}):
+            configs = find_configs(dirs=[str(config_dir)])
+            self.assertEqual([], configs)
+
     def test_find_configs(self) -> None:
         config_dir = self.tmpdir
         cwd_dir = config_dir / "cwd"


### PR DESCRIPTION
Summary:
So that the one below is valid and does not use any configs
```
TORCHXCONFIG="" torchx run
```

Differential Revision: D83086473


