### PR TITLE
(torchx/specs) Remove deprecated base_image attribute from Role

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -407,7 +407,6 @@ class Role:
     name: str
     image: str
     min_replicas: Optional[int] = None
-    base_image: Optional[str] = None  # DEPRECATED DO NOT SET, WILL BE REMOVED SOON
     entrypoint: str = MISSING
     args: List[str] = field(default_factory=list)
     env: Dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
Summary: `role.base_image` has been marked for deprecation for a few years. Remove it.

Differential Revision: D83780899


