### PR TITLE
(torchx/specs) Allow roles to specify their own workspaces

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -426,26 +426,42 @@ class Runner:
 
             sched._pre_build_validate(app, scheduler, resolved_cfg)
 
-            if workspace and isinstance(sched, WorkspaceMixin):
-                role = app.roles[0]
-                old_img = role.image
+            if isinstance(sched, WorkspaceMixin):
+                for i, role in enumerate(app.roles):
+                    role_workspace = role.workspace
 
-                logger.info(f"Checking for changes in workspace `{workspace}`...")
-                logger.info(
-                    'To disable workspaces pass: --workspace="" from CLI or workspace=None programmatically.'
-                )
-                sched.build_workspace_and_update_role2(role, workspace, resolved_cfg)
+                    if i == 0 and workspace:
+                        # NOTE: torchx originally took workspace as a runner arg and only applied the workspace to role[0]
+                        #   later, torchx added support for the workspace attr in Role
+                        #   for BC, give precedence to the workspace argument over the workspace attr for role[0]
+                        if role_workspace:
+                            logger.info(
+                                f"Using workspace={workspace} over role[{i}].workspace={role_workspace} for role[{i}]={role.name}."
+                                " To use the role's workspace attr pass: --workspace='' from CLI or workspace=None programmatically."  # noqa: B950
+                            )
+                        role_workspace = workspace
 
-                if old_img != role.image:
-                    logger.info(
-                        f"Built new image `{role.image}` based on original image `{old_img}`"
-                        f" and changes in workspace `{workspace}` for role[0]={role.name}."
-                    )
-                else:
-                    logger.info(
-                        f"Reusing original image `{old_img}` for role[0]={role.name}."
-                        " Either a patch was built or no changes to workspace was detected."
-                    )
+                    if role_workspace:
+                        old_img = role.image
+                        logger.info(
+                            f"Checking for changes in workspace `{role_workspace}` for role[{i}]={role.name}..."
+                        )
+                        # TODO kiuk@ once we deprecate the `workspace` argument in runner APIs we can simplify the signature of
+                        #   build_workspace_and_update_role2() to just taking the role and resolved_cfg
+                        sched.build_workspace_and_update_role2(
+                            role, role_workspace, resolved_cfg
+                        )
+
+                        if old_img != role.image:
+                            logger.info(
+                                f"Built new image `{role.image}` based on original image `{old_img}`"
+                                f" and changes in workspace `{role_workspace}` for role[{i}]={role.name}."
+                            )
+                        else:
+                            logger.info(
+                                f"Reusing original image `{old_img}` for role[{i}]={role.name}."
+                                " Either a patch was built or no changes to workspace was detected."
+                            )
 
             sched._validate(app, scheduler, resolved_cfg)
             dryrun_info = sched.submit_dryrun(app, resolved_cfg)

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -45,6 +45,7 @@ from torchx.specs.api import (
     UnknownAppException,
     UnknownSchedulerException,
     VolumeMount,
+    Workspace,
 )
 from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
 
@@ -236,4 +237,6 @@ __all__ = [
     "torchx_run_args_from_json",
     "TorchXRunArgs",
     "ALL",
+    "TORCHX_HOME",
+    "Workspace",
 ]

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -26,7 +26,7 @@ from typing import (
     Union,
 )
 
-from torchx.specs import AppDef, CfgVal, Role, runopts
+from torchx.specs import AppDef, CfgVal, Role, runopts, Workspace
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
@@ -86,71 +86,6 @@ class WorkspaceBuilder(Generic[PackageType, WorkspaceConfigType]):
 
         """
         pass
-
-
-@dataclass
-class Workspace:
-    """
-    Specifies a local "workspace" (a set of directories). Workspaces are ad-hoc built
-    into an (usually ephemeral) image. This effectively mirrors the local code changes
-    at job submission time.
-
-    For example:
-
-      1. ``projects={"~/github/torch": "torch"}`` copies ``~/github/torch/**`` into ``$REMOTE_WORKSPACE_ROOT/torch/**``
-      2. ``projects={"~/github/torch": ""}`` copies ``~/github/torch/**`` into ``$REMOTE_WORKSPACE_ROOT/**``
-
-    The exact location of ``$REMOTE_WORKSPACE_ROOT`` is implementation dependent and varies between
-    different implementations of :py:class:`~torchx.workspace.api.WorkspaceMixin`.
-    Check the scheduler documentation for details on which workspace it supports.
-
-    Note: ``projects`` maps the location of the local project to a sub-directory in the remote workspace root directory.
-    Typically the local project location is a directory path (e.g. ``/home/foo/github/torch``).
-
-
-    Attributes:
-        projects: mapping of local project to the sub-dir in the remote workspace dir.
-    """
-
-    projects: dict[str, str]
-
-    def is_unmapped_single_project(self) -> bool:
-        """
-        Returns ``True`` if this workspace only has 1 project
-        and its target mapping is an empty string.
-        """
-        return len(self.projects) == 1 and not next(iter(self.projects.values()))
-
-    @staticmethod
-    def from_str(workspace: str) -> "Workspace":
-        import yaml
-
-        projects = yaml.safe_load(workspace)
-        if isinstance(projects, str):  # single project workspace
-            projects = {projects: ""}
-        else:  # multi-project workspace
-            # Replace None mappings with "" (empty string)
-            projects = {k: ("" if v is None else v) for k, v in projects.items()}
-
-        return Workspace(projects)
-
-    def __str__(self) -> str:
-        """
-        Returns a string representation of the Workspace by concatenating
-        the project mappings using ';' as a delimiter and ':' between key and value.
-        If the single-project workspace with no target mapping, then simply
-        returns the src (local project dir)
-
-        NOTE: meant to be used for logging purposes not serde.
-          Therefore not symmetric with :py:func:`Workspace.from_str`.
-
-        """
-        if self.is_unmapped_single_project():
-            return next(iter(self.projects))
-        else:
-            return ";".join(
-                k if not v else f"{k}:{v}" for k, v in self.projects.items()
-            )
 
 
 class WorkspaceMixin(abc.ABC, Generic[T]):

--- a/torchx/workspace/test/api_test.py
+++ b/torchx/workspace/test/api_test.py
@@ -34,70 +34,15 @@ class TestWorkspace(WorkspaceMixin[None]):
 
 class WorkspaceTest(TestWithTmpDir):
 
-    def test_to_string_single_project_workspace(self) -> None:
-        self.assertEqual(
-            "/home/foo/bar",
-            str(Workspace(projects={"/home/foo/bar": ""})),
-        )
+    def build_workspace_and_update_role(
+        self, role: Role, workspace: str, cfg: Mapping[str, CfgVal]
+    ) -> None:
+        role.image = "bar"
+        role.metadata["workspace"] = workspace
 
-    def test_to_string_multi_project_workspace(self) -> None:
-        workspace = Workspace(
-            projects={
-                "/home/foo/workspace/myproj": "",
-                "/home/foo/github/torch": "torch",
-            }
-        )
-
-        self.assertEqual(
-            "/home/foo/workspace/myproj;/home/foo/github/torch:torch",
-            str(workspace),
-        )
-
-    def test_is_unmapped_single_project_workspace(self) -> None:
-        self.assertTrue(
-            Workspace(projects={"/home/foo/bar": ""}).is_unmapped_single_project()
-        )
-
-        self.assertFalse(
-            Workspace(projects={"/home/foo/bar": "baz"}).is_unmapped_single_project()
-        )
-
-        self.assertFalse(
-            Workspace(
-                projects={"/home/foo/bar": "", "/home/foo/torch": ""}
-            ).is_unmapped_single_project()
-        )
-
-        self.assertFalse(
-            Workspace(
-                projects={"/home/foo/bar": "", "/home/foo/torch": "pytorch"}
-            ).is_unmapped_single_project()
-        )
-
-    def test_from_str_single_project(self) -> None:
-        self.assertDictEqual(
-            {"/home/foo/bar": ""},
-            Workspace.from_str("/home/foo/bar").projects,
-        )
-
-        self.assertDictEqual(
-            {"/home/foo/bar": "baz"},
-            Workspace.from_str("/home/foo/bar: baz").projects,
-        )
-
-    def test_from_str_multi_project(self) -> None:
-        self.assertDictEqual(
-            {
-                "/home/foo/bar": "",
-                "/home/foo/third-party/verl": "verl",
-            },
-            Workspace.from_str(
-                """#
-/home/foo/bar:
-/home/foo/third-party/verl: verl
-"""
-            ).projects,
-        )
+        if not workspace.startswith("//"):
+            # to validate the merged workspace dir copy its content to the tmpdir
+            shutil.copytree(workspace, self.tmpdir)
 
     def test_build_and_update_role2_str_workspace(self) -> None:
         proj = self.tmpdir / "github" / "torch"


### PR DESCRIPTION
Summary:
So far you can only specify the workspace in the runner's API:

```
runner.dryrun(appdef, cfg, workspace=...)
```

in which case the workspace applies to ONLY `role[0]`.

This behavior was intentional since multi-role usecases of TorchX typically had a single "main" role that the application owner actually owned and the other roles were prepackaged apps (not part of your project).

This is no longer the case with applications such as reenforcement learning where the project encompasses multiple applications (e.g. trainer, generator, etc) therefore we need a more flexible way to specify a workspace per Role.

For BC this I'm maintaining the following behavior:

1. If `workspace` is specified as a runner argument then it takes precedence over `role[0].workspace`

2. Non-zero roles (e.g. `role[1], role[2], ...`) are unaffected by the workspace argument. That is their workspace attributes (e.g. `role[1].workspace`) are respected as is.

3. "disabling" workspace (e.g. passing `workspace=None` from the runner argument) can still build a workspace if the role's workspace attribute is not `None`.

NOTE: we need to do further optimization for cases where multiple roles have the same "image" and "workspace". In this case we only need to build the image+workspace once. But as it stands we end up building a separate ephemeral per role (even if the ephemeral is the SAME across all the roles). This isn't an issue practically since image builders like Docker are content addressed and caches layers.

Reviewed By: AbishekS

Differential Revision: D83793199


