### PR TITLE
Extend dependabot formatter-toolchain ignore to the uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,27 @@ updates:
       - dependency-name: "usort"
       - dependency-name: "stdlibs"
 
+  # Dependabot classifies this repo's Python security updates under the `uv`
+  # ecosystem (uv.lock is present; PR branches are `dependabot/uv/...`), and
+  # ignore conditions only apply to security updates when the entry's
+  # package-ecosystem matches — the `pip` ignore above did not block #1347.
+  # open-pull-requests-limit: 0 disables scheduled version updates for this
+  # entry; the ignore list below still applies to security updates.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 0
+    ignore:
+      # Keep in sync with the pip entry above (same rationale).
+      - dependency-name: "black"
+      - dependency-name: "ruff-api"
+      - dependency-name: "ufmt"
+      - dependency-name: "usort"
+      - dependency-name: "stdlibs"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot opened #1347 (black 25.11.0 → 26.3.1 in `fmt-requirements.txt`) on 8/4 despite the `ignore` block added in #1342 — the ignore **never matched**.

**Root cause:** #1347 (like #1348–#1350) is a dependabot *security update*, alert-driven rather than generated by a configured `updates` entry (alert GHSA-3936-cmfr-pm3m, created 8/4 08:26; PR followed at 09:17). This repo's Python updates are classified under the `uv` package ecosystem — the branch name encodes it (`dependabot/PACKAGE-MANAGER/...`):

```
dependabot/uv/black-26.3.1
```

`uv` is a separate `package-ecosystem` value from `pip` (which covers pip/pip-compile/pipenv/poetry only), and ignore conditions apply to security updates only through an `updates` entry whose ecosystem matches — so the ignore under `package-ecosystem: "pip"` **cannot block the uv-classified security-update stream**.

**This diff fixes this by** adding a `uv` entry carrying the same formatter-toolchain ignore list, so black/ruff-api/ufmt/usort/stdlibs are **ignored regardless of which ecosystem dependabot classifies the update under**. `open-pull-requests-limit: 0` keeps the new entry from generating scheduled version-update PRs (today's PR volume is unchanged); the limit does not affect ignore matching for security updates.

The `pip` entry is unchanged — it remains the match for anything dependabot classifies as pip.

## Test plan

1. YAML parses (`yaml.safe_load`) -> 3 entries: `pip`(limit 10), `uv`(limit 0), `github-actions`(limit 5)
2. Post-merge verification (config only takes effect on the default branch): Insights → Dependency graph → Dependabot shows the config parsing cleanly, and no new black/formatter PR appears on the next advisory
