### PR TITLE
(test)[torchx][apps/utils] Deflake process_monitor_test.test_start_on_file (#1352)

### DIFF
--- a/torchx/apps/utils/test/process_monitor_test.py
+++ b/torchx/apps/utils/test/process_monitor_test.py
@@ -85,29 +85,33 @@ class ProcessTest(unittest.TestCase):
         start_on_file = "memory://start"
         fs, path = fsspec.core.url_to_fs(start_on_file)
 
-        args = [
-            "--timeout",
-            "0.001",
-            "--poll_rate",
-            "0.001",
-            "--start_on_file",
-            start_on_file,
-            "--",
-            "echo",
-            "banana",
-        ]
+        def args(timeout: str) -> list[str]:
+            return [
+                "--timeout",
+                timeout,
+                "--poll_rate",
+                "0.001",
+                "--start_on_file",
+                start_on_file,
+                "--",
+                "echo",
+                "banana",
+            ]
 
         with patch("sys.stdout", new_callable=io.StringIO) as stdout:
             with self.assertRaisesRegex(SystemExit, f"^{TIMEOUT_EXIT_CODE}$"):
-                main(args)
+                main(args("0.001"))
             self.assertIn(
                 "reached timeout before launching, terminating...", stdout.getvalue()
             )
 
         fs.touch(path)
 
+        # long timeout: the process must not be killed before it exits on its
+        # own -- with a tiny timeout the monitor can win the race against the
+        # child's startup and terminate it (exit -15 instead of 0)
         with self.assertRaisesRegex(SystemExit, r"^0$"):
-            main(args)
+            main(args("60"))
 
     def test_exit_on_file(self) -> None:
         start_on_file = "memory://end"


### PR DESCRIPTION
Summary:

`test_start_on_file` is flaky on trunk (5 of the last 100 CI runs failed; flakiness score 22%, [test 281475243278128](https://www.internalfb.com/intern/test/281475243278128), T283680784).

**Root cause:** the test calls `main()` twice with the same args, including `--timeout 0.001`. The second call starts `echo` and expects a clean exit, but the 1 ms timeout gives the monitor a race against the child's startup: on a busy host the child is not done after the first poll, the monitor **terminates it, and the test sees exit `-15` instead of `0`**. Every failed run shows:

```
memory://start exists, starting process...
started process 8337
reached timeout, terminating...
process exited with exit code -15
```

**This diff fixes this by** giving each phase its own timeout: `0.001` for the first phase (start file absent, expects `TIMEOUT_EXIT_CODE` — the short timeout is the point) and `60` for the second phase (start file present, expects exit `0`), same as the other tests in this file. **The monitor can no longer kill the child before it exits on its own.**

Differential Revision: D115110512


