### PR TITLE
(bugfix)[torchx][version] Use the version arg in _get_torchx_image

### DIFF
--- a/torchx/test/version_test.py
+++ b/torchx/test/version_test.py
@@ -21,3 +21,12 @@ class VersionTest(unittest.TestCase):
         from torchx.version import __version__, TORCHX_IMAGE
 
         self.assertEqual(TORCHX_IMAGE, f"ghcr.io/pytorch/torchx:{__version__}")
+
+    def test_get_torchx_image_uses_version_arg(self) -> None:
+        from torchx.version import _get_torchx_image
+
+        self.assertEqual(
+            _get_torchx_image("0.1.2"),
+            "ghcr.io/pytorch/torchx:0.1.2",
+            "_get_torchx_image must tag the image with the version argument",
+        )

--- a/torchx/version.py
+++ b/torchx/version.py
@@ -28,10 +28,9 @@ def _version() -> str:
 __version__: str = _version()
 
 
-# Use the github container registry images corresponding to the current package
-# version.
+# Use the github container registry image tagged with the given version.
 def _get_torchx_image(torchx_version: str) -> str:
-    return f"ghcr.io/pytorch/torchx:{__version__}"
+    return f"ghcr.io/pytorch/torchx:{torchx_version}"
 
 
 # Check if there's an environment override on the default image.


### PR DESCRIPTION
Summary:
`_get_torchx_image(torchx_version)` ignored its argument and interpolated the module-global `__version__`, which **silently pins the image tag to the local package version** even though the `get_torchx_image` entry point contract calls the resolved function with the version to tag.

**Before**: `_get_torchx_image("0.1.2")` -> `ghcr.io/pytorch/torchx:{__version__}`

**This diff fixes this by** interpolating the parameter, so the function **tags the image with the version it is given**: `_get_torchx_image("0.1.2")` -> `ghcr.io/pytorch/torchx:0.1.2`. No behavior change for the in-tree caller (`TORCHX_IMAGE`), which already passes `__version__`.

Differential Revision: D115980862
