### PR TITLE
(cleanup)[torchx][specs] Remove the dead base_img_root macro sentinel

### DIFF
--- a/docs/source/specs.rst
+++ b/docs/source/specs.rst
@@ -48,14 +48,13 @@ Macros
 
 .. note::
 
-   In addition to the three macros listed in the class docstring, two more
-   attributes exist:
+   In addition to the three macros listed in the class docstring, one more
+   attribute exists:
 
    * ``macros.rank0_env`` -- expands to the **name** of the environment variable
      that provides the rank-0 (master) host address. Resolve it via shell
      expansion (``$${rank0_env}``) or in application code. Not available on all
      schedulers.
-   * ``macros.base_img_root`` -- **deprecated**. Do not use in new code.
 
 Run Configs
 --------------

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -29,8 +29,8 @@ from torchx.cli.cmd_run import (
     torchx_run_args_from_json,
     TorchXRunArgs,
 )
-from torchx.runner.config import ENV_TORCHXCONFIG
 from torchx.schedulers.local_scheduler import SignalException
+from torchx.settings import ENV_TORCHXCONFIG
 from torchx.specs import AppDryRunInfo, CfgVal
 
 

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -24,6 +24,7 @@ from typing import (
     TypeVar,
 )
 
+from torchx import settings
 from torchx.runner.events import log_event
 from torchx.schedulers import get_scheduler_factories, SchedulerFactory
 from torchx.schedulers.api import ListAppResponse, Scheduler, Stream
@@ -42,12 +43,7 @@ from torchx.specs import (
     Workspace,
 )
 from torchx.specs.finder import get_component
-from torchx.tracker.api import (
-    ENV_TORCHX_JOB_ID,
-    ENV_TORCHX_PARENT_RUN_ID,
-    ENV_TORCHX_TRACKERS,
-    tracker_config_env_var_name,
-)
+from torchx.tracker.api import tracker_config_env_var_name
 from torchx.util.session import get_session_id_or_create_new, TORCHX_INTERNAL_SESSION_ID
 from torchx.util.types import none_throws
 from torchx.workspace import WorkspaceMixin
@@ -67,9 +63,9 @@ T = TypeVar("T")
 
 def get_configured_trackers() -> dict[str, str | None]:
     tracker_names = list(get_configs(prefix="torchx", name="tracker").keys())
-    if ENV_TORCHX_TRACKERS in os.environ:
+    if settings.ENV_TORCHX_TRACKERS in os.environ:
         logger.info(f"Using TORCHX_TRACKERS={tracker_names} as tracker names")
-        tracker_names = os.environ[ENV_TORCHX_TRACKERS].split(",")
+        tracker_names = os.environ[settings.ENV_TORCHX_TRACKERS].split(",")
 
     tracker_names_with_config = {}
     for tracker_name in tracker_names:
@@ -350,10 +346,10 @@ class Runner:
                 f"No roles for app: {app.name}. Did you forget to add roles to AppDef?"
             )
 
-        if ENV_TORCHX_PARENT_RUN_ID in os.environ:
-            parent_run_id = os.environ[ENV_TORCHX_PARENT_RUN_ID]
+        if settings.ENV_TORCHX_PARENT_RUN_ID in os.environ:
+            parent_run_id = os.environ[settings.ENV_TORCHX_PARENT_RUN_ID]
             logger.info(
-                f"Using {ENV_TORCHX_PARENT_RUN_ID}={parent_run_id} env variable as tracker parent run id"
+                f"Using {settings.ENV_TORCHX_PARENT_RUN_ID}={parent_run_id} env variable as tracker parent run id"
             )
 
         configured_trackers = get_configured_trackers()
@@ -376,16 +372,18 @@ class Runner:
             #    - inject it as TORCHX_TRACKERS=names (it is expected that entrypoints are defined)
             #    - for each backend check configuration file, if exists:
             #        - inject it as TORCHX_TRACKER_<name>_CONFIGFILE=filename
-            role.env[ENV_TORCHX_JOB_ID] = make_app_handle(
+            role.env[settings.ENV_TORCHX_JOB_ID] = make_app_handle(
                 scheduler, self._name, macros.app_id
             )
             role.env[TORCHX_INTERNAL_SESSION_ID] = get_session_id_or_create_new()
 
             if parent_run_id:
-                role.env[ENV_TORCHX_PARENT_RUN_ID] = parent_run_id
+                role.env[settings.ENV_TORCHX_PARENT_RUN_ID] = parent_run_id
 
             if configured_trackers:
-                role.env[ENV_TORCHX_TRACKERS] = ",".join(configured_trackers.keys())
+                role.env[settings.ENV_TORCHX_TRACKERS] = ",".join(
+                    configured_trackers.keys()
+                )
 
             for name, config in configured_trackers.items():
                 if config:

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -172,8 +172,6 @@ from torchx.util import entrypoints
 
 CONFIG_FILE = ".torchxconfig"
 CONFIG_PREFIX_DELIM = ":"
-# BC re-export — new code should import from torchx.settings
-ENV_TORCHXCONFIG: str = settings.ENV_TORCHXCONFIG
 DEFAULT_CONFIG_DIRS = [str(Path.home()), str(Path.cwd())]
 
 _NONE = "None"
@@ -486,14 +484,14 @@ def find_configs(dirs: Iterable[str] | None = None) -> list[str]:
 
     """
 
-    config = os.getenv(ENV_TORCHXCONFIG)
+    config = os.getenv(settings.ENV_TORCHXCONFIG)
     if config is not None:
         if not config:
             return []
         configfile = Path(config)
         if not configfile.is_file():
             raise FileNotFoundError(
-                f"`{ENV_TORCHXCONFIG}={config}` does not exist or is not a file."
+                f"`{settings.ENV_TORCHXCONFIG}={config}` does not exist or is not a file."
             )
         return [str(configfile)]
     else:

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -22,6 +22,7 @@ from torchx.schedulers.local_scheduler import (
     create_scheduler,
     LocalDirectoryImageProvider,
 )
+from torchx.settings import ENV_TORCHX_JOB_ID, ENV_TORCHX_PARENT_RUN_ID
 from torchx.specs import (
     AppDef,
     AppDryRunInfo,
@@ -37,7 +38,6 @@ from torchx.specs import (
 )
 from torchx.specs.finder import ComponentNotFoundException
 from torchx.test.fixtures import TestWithTmpDir
-from torchx.tracker.api import ENV_TORCHX_JOB_ID, ENV_TORCHX_PARENT_RUN_ID
 from torchx.util.types import none_throws
 from torchx.workspace import WorkspaceMixin
 

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -17,7 +17,6 @@ from unittest.mock import patch
 from torchx.runner.config import (
     apply,
     dump,
-    ENV_TORCHXCONFIG,
     find_configs,
     get_config,
     get_configs,
@@ -31,6 +30,7 @@ from torchx.schedulers.api import (
     Stream,
     StructuredOpts,
 )
+from torchx.settings import ENV_TORCHXCONFIG
 from torchx.specs import AppDef, AppDryRunInfo, CfgVal, runopts, Workspace
 from torchx.test.fixtures import TestWithTmpDir
 

--- a/torchx/schedulers/aws_batch_scheduler.py
+++ b/torchx/schedulers/aws_batch_scheduler.py
@@ -77,13 +77,6 @@ from torchx.specs.named_resources_aws import instance_type_from_resource
 from torchx.util.types import none_throws
 from torchx.workspace.docker_workspace import DockerWorkspaceMixin
 
-# BC re-exports — new code should import from torchx.settings
-ENV_TORCHX_ROLE_IDX: str = settings.ENV_TORCHX_ROLE_IDX
-
-ENV_TORCHX_ROLE_NAME: str = settings.ENV_TORCHX_ROLE_NAME
-
-ENV_TORCHX_IMAGE: str = settings.ENV_TORCHX_IMAGE
-
 DEFAULT_ROLE_NAME = "node"
 
 TAG_TORCHX_VER = "torchx.pytorch.org/version"
@@ -547,9 +540,9 @@ class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
                 rank0_env="AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS",
             )
             role = values.apply(role)
-            role.env[ENV_TORCHX_ROLE_IDX] = str(role_idx)
-            role.env[ENV_TORCHX_ROLE_NAME] = str(role.name)
-            role.env[ENV_TORCHX_IMAGE] = role.image
+            role.env[settings.ENV_TORCHX_ROLE_IDX] = str(role_idx)
+            role.env[settings.ENV_TORCHX_ROLE_NAME] = str(role.name)
+            role.env[settings.ENV_TORCHX_IMAGE] = role.image
 
             nodes.append(
                 _role_to_node_properties(
@@ -651,7 +644,7 @@ class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
             command = container["command"]
             roles.append(
                 Role(
-                    name=env.get(ENV_TORCHX_ROLE_NAME, DEFAULT_ROLE_NAME),
+                    name=env.get(settings.ENV_TORCHX_ROLE_NAME, DEFAULT_ROLE_NAME),
                     num_replicas=_parse_num_replicas(
                         node_group["targetNodes"], num_nodes
                     ),
@@ -698,7 +691,7 @@ class AWSBatchScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
         for i, node in enumerate(nodes):
             container = node["container"]
             env = {opt["name"]: opt["value"] for opt in container["environment"]}
-            node_role = env.get(ENV_TORCHX_ROLE_NAME, DEFAULT_ROLE_NAME)
+            node_role = env.get(settings.ENV_TORCHX_ROLE_NAME, DEFAULT_ROLE_NAME)
             start_idx, _ = _parse_start_and_end_idx(
                 node["targetNodes"],
                 node_properties["numNodes"],

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -86,9 +86,6 @@ LABEL_APP_ID: str = "torchx.pytorch.org/app-id"
 LABEL_ROLE_NAME: str = "torchx.pytorch.org/role-name"
 LABEL_REPLICA_ID: str = "torchx.pytorch.org/replica-id"
 
-# BC re-export — new code should import from torchx.settings
-ENV_TORCHX_IMAGE: str = settings.ENV_TORCHX_IMAGE
-
 NETWORK = "torchx"
 
 
@@ -292,7 +289,7 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
 
                 # configure distributed host envs
                 env["TORCHX_RANK0_HOST"] = rank0_name
-                env[ENV_TORCHX_IMAGE] = replica_role.image
+                env[settings.ENV_TORCHX_IMAGE] = replica_role.image
 
                 c = DockerContainer(
                     image=replica_role.image,

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -199,10 +199,6 @@ class Opts(StructuredOpts):
     """Sets CUDA_VISIBLE_DEVICES for roles that request GPU resources."""
 
 
-# Type alias for backwards compatibility with existing code
-LocalOpts = Mapping[str, CfgVal]
-
-
 class LocalDirectoryImageProvider(ImageProvider):
     """
     Interprets the image name as the path to a directory on
@@ -219,7 +215,7 @@ class LocalDirectoryImageProvider(ImageProvider):
 
     """
 
-    def __init__(self, cfg: LocalOpts) -> None:
+    def __init__(self, cfg: Mapping[str, CfgVal]) -> None:
         pass
 
     def fetch(self, image: str) -> str:
@@ -266,7 +262,7 @@ class CWDImageProvider(ImageProvider):
 
     """
 
-    def __init__(self, cfg: LocalOpts) -> None:
+    def __init__(self, cfg: Mapping[str, CfgVal]) -> None:
         pass
 
     def fetch(self, image: str) -> str:
@@ -551,7 +547,7 @@ def _register_termination_signals() -> None:
         signal.signal(signal.SIGINT, _terminate_process_handler)
 
 
-class LocalScheduler(Scheduler[LocalOpts]):
+class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
     """
     Schedules on localhost. Containers are modeled as processes and
     certain properties of the container that are either not relevant
@@ -606,7 +602,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
     def __init__(
         self,
         session_name: str,
-        image_provider_class: Callable[[LocalOpts], ImageProvider],
+        image_provider_class: Callable[[Mapping[str, CfgVal]], ImageProvider],
         cache_size: int = 100,
         extra_paths: list[str] | None = None,
     ) -> None:
@@ -829,7 +825,7 @@ class LocalScheduler(Scheduler[LocalOpts]):
         return app_id
 
     def _submit_dryrun(
-        self, app: AppDef, cfg: LocalOpts
+        self, app: AppDef, cfg: Mapping[str, CfgVal]
     ) -> AppDryRunInfo[PopenRequest]:
         request = self._to_popen_request(app, cfg)
         return AppDryRunInfo(
@@ -949,7 +945,7 @@ Reduce requested GPU resources or use a host with more GPUs
     def _to_popen_request(
         self,
         app: AppDef,
-        cfg: LocalOpts,
+        cfg: Mapping[str, CfgVal],
     ) -> PopenRequest:
         """
         Converts the application and cfg into a ``PopenRequest``.
@@ -1202,7 +1198,9 @@ def create_scheduler(
     session_name: str,
     cache_size: int = 100,
     extra_paths: list[str] | None = None,
-    image_provider_class: Callable[[LocalOpts], ImageProvider] = CWDImageProvider,
+    image_provider_class: Callable[
+        [Mapping[str, CfgVal]], ImageProvider
+    ] = CWDImageProvider,
     **kwargs: Any,
 ) -> LocalScheduler:
     return LocalScheduler(

--- a/torchx/schedulers/test/aws_batch_scheduler_test.py
+++ b/torchx/schedulers/test/aws_batch_scheduler_test.py
@@ -21,14 +21,13 @@ from torchx.schedulers.aws_batch_scheduler import (
     _role_to_node_properties,
     AWSBatchScheduler,
     create_scheduler,
-    ENV_TORCHX_IMAGE,
-    ENV_TORCHX_ROLE_NAME,
     Opts,
     parse_ulimits,
     resource_from_resource_requirements,
     resource_requirements_from_resource,
     to_millis_since_epoch,
 )
+from torchx.settings import ENV_TORCHX_IMAGE, ENV_TORCHX_ROLE_NAME
 from torchx.specs import AppState, Resource
 
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -210,7 +210,6 @@ class macros:
     """
 
     img_root = "${img_root}"
-    base_img_root = "${base_img_root}"
     app_id = "${app_id}"
     replica_id = "${replica_id}"
 
@@ -227,7 +226,6 @@ class macros:
         app_id: str
         replica_id: str
         rank0_env: str
-        base_img_root: str = "DEPRECATED"
 
         def apply(self, role: "Role") -> "Role":
             """Returns a deep copy of ``role`` with macros substituted."""

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -1064,7 +1064,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root",
             app_id="app_id",
             replica_id="replica_id",
-            base_img_root="base_img_root",
             rank0_env="rank0_env",
         )
         for key, val in asdict(v).items():
@@ -1083,7 +1082,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root",
             app_id="app_id",
             replica_id="replica_id",
-            base_img_root="base_img_root",
             rank0_env="rank0_env",
         )
         newrole = v.apply(role)
@@ -1108,7 +1106,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root_value",
             app_id="app_id_value",
             replica_id="replica_id_value",
-            base_img_root="base_img_root_value",
             rank0_env="rank0_env_value",
         )
         newrole = v.apply(role)
@@ -1141,7 +1138,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root_value",
             app_id="app_id_value",
             replica_id="replica_id_value",
-            base_img_root="base_img_root_value",
             rank0_env="rank0_env_value",
         )
         newrole = v.apply(role)
@@ -1175,7 +1171,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root_value",
             app_id="app_id_value",
             replica_id="replica_id_value",
-            base_img_root="base_img_root_value",
             rank0_env="rank0_env_value",
         )
         newrole = v.apply(role)
@@ -1202,7 +1197,6 @@ class MacrosTest(unittest.TestCase):
             img_root="img_root_value",
             app_id="app_id_value",
             replica_id="replica_id_value",
-            base_img_root="base_img_root_value",
             rank0_env="rank0_env_value",
         )
         newrole = v.apply(role)

--- a/torchx/test/settings_test.py
+++ b/torchx/test/settings_test.py
@@ -40,34 +40,6 @@ class SettingsBCReexportTest(unittest.TestCase):
     so ``is`` checks and identity-based caching remain correct.
     """
 
-    def test_bc_reexport_tracker(self) -> None:
-        from torchx.tracker import api as tracker_api
-
-        self.assertIs(
-            tracker_api.ENV_TORCHX_TRACKERS,
-            settings.ENV_TORCHX_TRACKERS,
-            "tracker re-export should be the same object",
-        )
-        self.assertIs(
-            tracker_api.ENV_TORCHX_PARENT_RUN_ID,
-            settings.ENV_TORCHX_PARENT_RUN_ID,
-            "tracker re-export should be the same object",
-        )
-        self.assertIs(
-            tracker_api.ENV_TORCHX_JOB_ID,
-            settings.ENV_TORCHX_JOB_ID,
-            "tracker re-export should be the same object",
-        )
-
-    def test_bc_reexport_config(self) -> None:
-        from torchx.runner import config
-
-        self.assertIs(
-            config.ENV_TORCHXCONFIG,
-            settings.ENV_TORCHXCONFIG,
-            "config re-export should be the same object",
-        )
-
     def test_bc_reexport_session(self) -> None:
         from torchx.util import session
 
@@ -75,32 +47,4 @@ class SettingsBCReexportTest(unittest.TestCase):
             session.TORCHX_INTERNAL_SESSION_ID,
             settings.TORCHX_INTERNAL_SESSION_ID,
             "session re-export should be the same object",
-        )
-
-    def test_bc_reexport_aws_batch(self) -> None:
-        from torchx.schedulers import aws_batch_scheduler
-
-        self.assertIs(
-            aws_batch_scheduler.ENV_TORCHX_ROLE_IDX,
-            settings.ENV_TORCHX_ROLE_IDX,
-            "aws_batch re-export should be the same object",
-        )
-        self.assertIs(
-            aws_batch_scheduler.ENV_TORCHX_ROLE_NAME,
-            settings.ENV_TORCHX_ROLE_NAME,
-            "aws_batch re-export should be the same object",
-        )
-        self.assertIs(
-            aws_batch_scheduler.ENV_TORCHX_IMAGE,
-            settings.ENV_TORCHX_IMAGE,
-            "aws_batch re-export should be the same object",
-        )
-
-    def test_bc_reexport_docker(self) -> None:
-        from torchx.schedulers import docker_scheduler
-
-        self.assertIs(
-            docker_scheduler.ENV_TORCHX_IMAGE,
-            settings.ENV_TORCHX_IMAGE,
-            "docker re-export should be the same object",
         )

--- a/torchx/test/version_test.py
+++ b/torchx/test/version_test.py
@@ -21,3 +21,12 @@ class VersionTest(unittest.TestCase):
         from torchx.version import __version__, TORCHX_IMAGE
 
         self.assertEqual(TORCHX_IMAGE, f"ghcr.io/pytorch/torchx:{__version__}")
+
+    def test_get_torchx_image_uses_version_arg(self) -> None:
+        from torchx.version import _get_torchx_image
+
+        self.assertEqual(
+            _get_torchx_image("0.1.2"),
+            "ghcr.io/pytorch/torchx:0.1.2",
+            "_get_torchx_image must tag the image with the version argument",
+        )

--- a/torchx/tracker/api.py
+++ b/torchx/tracker/api.py
@@ -20,11 +20,6 @@ from torchx.util.modules import load_module
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# BC re-exports — new code should import from torchx.settings
-ENV_TORCHX_TRACKERS: str = settings.ENV_TORCHX_TRACKERS
-ENV_TORCHX_PARENT_RUN_ID: str = settings.ENV_TORCHX_PARENT_RUN_ID
-ENV_TORCHX_JOB_ID: str = settings.ENV_TORCHX_JOB_ID
-
 
 @dataclass
 class TrackerSource:
@@ -128,12 +123,14 @@ def tracker_config_env_var_name(entrypoint_key: str) -> str:
 
 
 def _extract_tracker_name_and_config_from_environ() -> Mapping[str, str | None]:
-    if ENV_TORCHX_TRACKERS not in os.environ:
+    if settings.ENV_TORCHX_TRACKERS not in os.environ:
         logger.info("No trackers were configured, skipping setup.")
         return {}
 
-    tracker_backend_entrypoints = os.environ[ENV_TORCHX_TRACKERS]
-    logger.info(f"Trackers: {ENV_TORCHX_TRACKERS}={tracker_backend_entrypoints}")
+    tracker_backend_entrypoints = os.environ[settings.ENV_TORCHX_TRACKERS]
+    logger.info(
+        f"Trackers: {settings.ENV_TORCHX_TRACKERS}={tracker_backend_entrypoints}"
+    )
 
     entries = {}
     for entrypoint_key in tracker_backend_entrypoints.split(","):
@@ -228,11 +225,11 @@ class AppRun:
 
         """
 
-        torchx_job_id = os.getenv(ENV_TORCHX_JOB_ID, default="<UNDEFINED>")
+        torchx_job_id = os.getenv(settings.ENV_TORCHX_JOB_ID, default="<UNDEFINED>")
 
         trackers = trackers_from_environ()
-        if ENV_TORCHX_PARENT_RUN_ID in os.environ:
-            parent_run_id = os.environ[ENV_TORCHX_PARENT_RUN_ID]
+        if settings.ENV_TORCHX_PARENT_RUN_ID in os.environ:
+            parent_run_id = os.environ[settings.ENV_TORCHX_PARENT_RUN_ID]
             logger.info(f"Tracker parent run ID: '{parent_run_id}'")
             for tracker in trackers:
                 tracker.add_source(torchx_job_id, parent_run_id, artifact_name=None)

--- a/torchx/tracker/mlflow.py
+++ b/torchx/tracker/mlflow.py
@@ -17,15 +17,10 @@ from urllib.parse import urlparse
 import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import Experiment, Run
+from torchx import settings
 from torchx.distributed import on_rank0_first
 from torchx.runner.config import get_configs
-from torchx.tracker.api import (
-    ENV_TORCHX_JOB_ID,
-    Lineage,
-    TrackerArtifact,
-    TrackerBase,
-    TrackerSource,
-)
+from torchx.tracker.api import Lineage, TrackerArtifact, TrackerBase, TrackerSource
 
 log: Logger = getLogger(__name__)
 TAG_ARTIFACT_MD_PREFIX = "torchx.artifact.metadata"
@@ -109,7 +104,7 @@ class MLflowTracker(TrackerBase):
             # so this env var will exist if the job is launched with torchx
             # if so, then prime the run here so that rank0 creates the run first
             # and the rest of the ranks can point to the existing run
-            run_name = os.getenv(ENV_TORCHX_JOB_ID)
+            run_name = os.getenv(settings.ENV_TORCHX_JOB_ID)
             if run_name:
                 run = self.get_run(run_name)
                 log.info(f"Primed run `{run.info.run_name}` ({run.info.run_id})")

--- a/torchx/tracker/test/api_test.py
+++ b/torchx/tracker/test/api_test.py
@@ -11,14 +11,16 @@ from typing import cast, DefaultDict, Iterable, Mapping
 from unittest import mock, TestCase
 from unittest.mock import MagicMock, patch
 
+from torchx.settings import (
+    ENV_TORCHX_JOB_ID,
+    ENV_TORCHX_PARENT_RUN_ID,
+    ENV_TORCHX_TRACKERS,
+)
 from torchx.tracker import app_run_from_env
 from torchx.tracker.api import (
     _extract_tracker_name_and_config_from_environ,
     AppRun,
     build_trackers,
-    ENV_TORCHX_JOB_ID,
-    ENV_TORCHX_PARENT_RUN_ID,
-    ENV_TORCHX_TRACKERS,
     Lineage,
     tracker_config_env_var_name,
     TrackerArtifact,

--- a/torchx/version.py
+++ b/torchx/version.py
@@ -28,10 +28,9 @@ def _version() -> str:
 __version__: str = _version()
 
 
-# Use the github container registry images corresponding to the current package
-# version.
+# Use the github container registry image tagged with the given version.
 def _get_torchx_image(torchx_version: str) -> str:
-    return f"ghcr.io/pytorch/torchx:{__version__}"
+    return f"ghcr.io/pytorch/torchx:{torchx_version}"
 
 
 # Check if there's an environment override on the default image.


### PR DESCRIPTION
Summary:
Deletes the long-deprecated `macros.base_img_root` template variable and the `macros.Values.base_img_root = "DEPRECATED"` sentinel field. An fbsource-wide sweep (all 17 `base_img_root` hits accounted for) found **no producer or consumer** outside the definition, its own tests, and one docs bullet: no component references `${base_img_root}` and nothing constructs `Values(base_img_root=...)` outside `specs/test/api_test.py`. `torchx.specs.fb.macros.Values` inherits the field, so the serialized macro-values dict (fed only to `Template.safe_substitute`, where an extra key is inert) drops the `base_img_root` key — `api_meta_test`'s `to_dict()` expectation updated accordingly.

NOTE: the adjacent deprecated `Role.overrides` + `__getattribute__` lazy-resolution machinery is deliberately NOT removed — the APF launcher still produces it at runtime (`apf/launcher/torchx_utils.py` sets `role.overrides` from `PkgInfo.lazy_overrides`, including an async fbpkg-build future that resolves through `Role.__getattribute__` on first `role.image` read).

Differential Revision: D115980859
