### PR TITLE
(bugfix)[torchx][runner] Delegate configfile value casting to runopt.cast_to_type (#1366)

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -539,17 +539,6 @@ def load(scheduler: str, f: TextIO, cfg: dict[str, CfgVal]) -> None:
                         f" Remove the entry from the config file to no longer see this warning"
                     )
                 else:
-                    if opt.opt_type is bool:
-                        # need to handle bool specially since str -> bool is based on
-                        # str emptiness not value (e.g. bool("False") == True)
-                        cfg[name] = config.getboolean(section, name)
-                    elif opt.is_type_list_of_str:
-                        cfg[name] = value.split(";")
-                    elif opt.is_type_dict_of_str:
-                        cfg[name] = {
-                            s.split(":", 1)[0]: s.split(":", 1)[1]
-                            for s in value.replace(",", ";").split(";")
-                        }
-                    else:
-                        # pyre-ignore[29]
-                        cfg[name] = opt.opt_type(value)
+                    # delegate casting to the runopt itself so configfile
+                    # values parse exactly like CLI `-cfg` values
+                    cfg[name] = opt.cast_to_type(value)

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -375,6 +375,56 @@ image = foobar_custom
         self.assertEqual("/home/bob/logs", cfg.get("log_dir"))
         self.assertEqual(True, cfg.get("prepend_cwd"))
 
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_casts_like_cast_to_type(self, _) -> None:
+        """load() must parse configfile values exactly like ``runopt.cast_to_type``."""
+        config = """#
+[test]
+bTrue = 1
+l = a,b
+l_typing = a;
+"""
+        cfg: dict[str, CfgVal] = {}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+
+        opts = TestScheduler("test").run_opts()
+        for name, raw in (("bTrue", "1"), ("l", "a,b"), ("l_typing", "a;")):
+            opt = opts.get(name)
+            assert opt is not None, f"TestScheduler must define runopt {name}"
+            self.assertEqual(
+                opt.cast_to_type(raw),
+                cfg[name],
+                f"load() and cast_to_type() must agree on {name}={raw!r}",
+            )
+
+        # pin the previously divergent parses
+        self.assertEqual(
+            True, cfg["bTrue"], 'bool "1" is True (INI getboolean vocabulary)'
+        )
+        self.assertEqual(
+            ["a", "b"], cfg["l"], "lists accept ',' delimiters like the CLI"
+        )
+        self.assertEqual(["a"], cfg["l_typing"], "empty trailing elements are dropped")
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_ini_bool_vocabulary_round_trips(self, _) -> None:
+        """INI booleans written as yes/on/1 (getboolean vocabulary) load as True."""
+        config = """#
+[test]
+bTrue = yes
+bFalse = off
+"""
+        cfg: dict[str, CfgVal] = {}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual(True, cfg["bTrue"], "yes must load as True")
+        self.assertEqual(False, cfg["bFalse"], "off must load as False")
+
     def test_no_override_load(self) -> None:
         cfg: dict[str, CfgVal] = {"log_dir": "/foo/bar", "debug": 1}
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1073,7 +1073,8 @@ class runopt:
         Below are the cast rules for each option type and value literal:
 
         1. opt_type=str, value="foo" -> "foo"
-        1. opt_type=bool, value="True"/"False" -> True/False
+        1. opt_type=bool, value="true"/"1"/"yes"/"on" -> True (case-insensitive; INI vocabulary)
+        1. opt_type=bool, value="false"/"0"/"no"/"off" -> False (anything else raises ValueError)
         1. opt_type=int, value="1" -> 1
         1. opt_type=float, value="1.1" -> 1.1
         1. opt_type=list[str]/List[str], value="a,b,c" or value="a;b;c" -> ["a", "b", "c"]
@@ -1087,7 +1088,17 @@ class runopt:
         if self.opt_type is None:
             raise ValueError("runopt's opt_type cannot be `None`")
         elif self.opt_type == bool:
-            return value.lower() == "true"
+            # accept the INI boolean vocabulary (configparser.getboolean)
+            # case-insensitively; reject anything else loudly
+            lowered = value.lower()
+            if lowered in ("true", "1", "yes", "on"):
+                return True
+            elif lowered in ("false", "0", "no", "off"):
+                return False
+            raise ValueError(
+                f"`{value}` is not a valid bool literal, expected one of"
+                " (case-insensitive): true/1/yes/on or false/0/no/off"
+            )
         elif self.opt_type in (List[str], list[str]):
             # lists may be ; or , delimited
             # also deal with trailing "," by removing empty strings

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -1050,6 +1050,20 @@ class RunConfigTest(unittest.TestCase):
         self.assertTrue(cfg.get("preemptible"))
         self.assertIsNone(cfg.get("unknown"))
 
+    def test_runopt_cast_to_type_bool_vocabulary(self) -> None:
+        opt = runopt(default=False, opt_type=bool, is_required=False, help="help")
+        for literal in ("true", "True", "TRUE", "1", "yes", "Yes", "on", "ON"):
+            self.assertTrue(opt.cast_to_type(literal), f"`{literal}` must cast to True")
+        for literal in ("false", "False", "FALSE", "0", "no", "No", "off", "OFF"):
+            self.assertFalse(
+                opt.cast_to_type(literal), f"`{literal}` must cast to False"
+            )
+
+    def test_runopt_cast_to_type_bool_rejects_garbage(self) -> None:
+        opt = runopt(default=False, opt_type=bool, is_required=False, help="help")
+        with self.assertRaisesRegex(ValueError, "garbage"):
+            opt.cast_to_type("garbage")
+
     def test_runopt_cast_to_type_typing_list(self) -> None:
         opt = runopt(default="", opt_type=List[str], is_required=False, help="help")
         self.assertEqual(["a", "b", "c"], opt.cast_to_type("a,b,c"))


### PR DESCRIPTION
Summary:

`runner/config.py load()` hand-cast INI values with logic that drifted from `runopt.cast_to_type` (`specs/api.py`) — the caster used for CLI `-cfg` values — so the same scheduler option parsed differently depending on whether it came from `.torchxconfig` or the command line:

- bool: `getboolean` accepted `1/yes/on`; `cast_to_type` is strict `== "true"` — `prepend_cwd = 1` **inverted** between the two paths
- list: configfile split on `;` only (`a,b` stayed one element) and kept empty trailing elements (`a;` -> `["a", ""]`); `cast_to_type` accepts both delimiters and drops empties

**This diff fixes this by** deleting the hand-cast chain and delegating to `opt.cast_to_type(value)`, so both paths parse identically — and widening `cast_to_type`'s bool branch AT THE CHOKEPOINT to the full INI vocabulary, case-insensitively: `true/1/yes/on` -> `True`, `false/0/no/off` -> `False`, anything else raises `ValueError` naming the value (reject-don't-guess). Configfiles written for `getboolean` keep parsing as they always did, and the CLI `-cfg flag=1` path (previously silently `False`) now parses `True`; garbage stays loud. The `dump()` -> `load()` roundtrip is unaffected (`dump` joins lists/dicts with `;`, which both parsers read the same way).

Differential Revision: D116021590
