### PR TITLE
(bugfix)[torchx][specs] Fix Role.overrides, Resource.copy, and unknown-scheduler bugs (#1368)

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -40,6 +40,7 @@ from torchx.specs import (
     parse_app_handle,
     runopts,
     UnknownAppException,
+    UnknownSchedulerException,
     Workspace,
 )
 from torchx.specs.finder import get_component
@@ -625,9 +626,7 @@ class Runner:
                 sched = factory(self._name, **self._scheduler_params)
                 self._scheduler_instances[scheduler] = sched
         if not sched:
-            raise KeyError(
-                f"Undefined scheduler backend: {scheduler}. Use one of: {self._scheduler_factories.keys()}"
-            )
+            raise UnknownSchedulerException(scheduler)
         return sched
 
     def _scheduler_app_id(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -34,6 +34,7 @@ from torchx.specs import (
     Role,
     runopts,
     UnknownAppException,
+    UnknownSchedulerException,
     Workspace,
 )
 from torchx.specs.finder import ComponentNotFoundException
@@ -77,6 +78,19 @@ class RunnerTest(TestWithTmpDir):
             },
         ) as runner:
             yield runner
+
+    def test_unknown_scheduler(self, _) -> None:
+        with self.get_runner() as runner:
+            role = Role(
+                name="sleep",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="sleep.sh",
+                args=["1"],
+            )
+            app = AppDef("name", roles=[role])
+            with self.assertRaises(UnknownSchedulerException):
+                runner.run(app, scheduler="does_not_exist", cfg=self.cfg)
 
     def test_validate_no_roles(self, _: MagicMock) -> None:
         with self.get_runner() as runner:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -7,14 +7,16 @@
 # pyre-strict
 
 import asyncio
+import concurrent.futures
 import copy
 import inspect
 import json
-import logging as logger
+import logging
 import os
 import pathlib
 import re
 import shutil
+import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -22,6 +24,7 @@ from json import JSONDecodeError
 from string import Template
 from typing import (
     Any,
+    Awaitable,
     Callable,
     Dict,
     Generic,
@@ -35,6 +38,8 @@ from typing import (
 )
 
 from torchx.util.types import to_dict
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 _APP_STATUS_FORMAT_TEMPLATE = """AppStatus:
     State: ${state}
@@ -156,7 +161,8 @@ class Resource:
             gpu=original.gpu,
             memMB=original.memMB,
             capabilities=res_capabilities,
-            devices=original.devices,
+            devices=dict(original.devices),
+            tags=dict(original.tags),
         )
 
 
@@ -230,15 +236,28 @@ class macros:
         def apply(self, role: "Role") -> "Role":
             """Returns a deep copy of ``role`` with macros substituted."""
 
-            # Overrides might contain future values which can't be serialized so taken out for the copy
-            overrides = role.overrides
-            if len(overrides) > 0:
-                logger.warning(
-                    "Role overrides are not supported for macros. Overrides will not be copied"
+            # Overrides may hold futures/coroutines that cannot be deep-copied,
+            # so detach them during the copy (restoring them on the original).
+            # The copy SHARES the dict with the original: resolution writes the
+            # resolved value back in place, so whichever role resolves an
+            # override first, both see the plain value thereafter (single-shot
+            # coroutines are resolved at most once).
+            original = role
+            overrides = original.overrides
+            if any(key != _OVERRIDES_LOCK_KEY for key in overrides):
+                logger.debug(
+                    "role overrides are shared with the macro-substituted copy"
                 )
-                role.overrides = {}
-            role = copy.deepcopy(role)
-            role.overrides = overrides
+                original.overrides = {}
+                try:
+                    role = copy.deepcopy(original)
+                finally:
+                    original.overrides = overrides
+                role.overrides = overrides
+            else:
+                # nothing to share — a plain deep copy gives the copy its own
+                # (empty) overrides dict instead of sharing the original's
+                role = copy.deepcopy(original)
 
             role.args = [self.substitute(arg) for arg in role.args]
             role.env = {key: self.substitute(arg) for key, arg in role.env.items()}
@@ -409,6 +428,139 @@ class Workspace:
             )
 
 
+# sentinel distinguishing "no override registered" from a legitimate None value
+_NO_OVERRIDE: object = object()
+
+# reserved key under which an overrides dict stores its own resolution lock.
+# NOT an identifier, so it can never collide with an attribute name; copies
+# share the overrides dict by reference, so they share the lock the same way.
+_OVERRIDES_LOCK_KEY: str = "<overrides resolution lock>"
+
+# guards only the mint-on-first-use of a dict's resolution lock (two cheap
+# dict ops); never held across resolution itself
+_overrides_lock_mint_guard = threading.Lock()
+
+
+class _OverridesLock:
+    """Reserved-key dict entry (see ``_OVERRIDES_LOCK_KEY``) holding an
+    overrides dict's single-flight resolution lock."""
+
+    __slots__ = ("lock",)
+
+    def __init__(self) -> None:
+        # re-entrant: a producer that itself reads another overridden
+        # attribute on the same Role re-acquires this lock on the same
+        # thread — an RLock resolves the nested override instead of
+        # self-deadlocking (a plain Lock would)
+        self.lock = threading.RLock()
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "_OverridesLock":
+        # locks cannot be deep-copied; sharing is also the right semantic —
+        # a deep-copied dict keeps single-flight with its source
+        return self
+
+
+def _overrides_resolution_lock(ov: dict[str, Any]) -> "threading.RLock":
+    """Returns ``ov``'s single-flight resolution lock, minting it on first use.
+
+    Per-overrides-dict (never process-wide) so a slow producer on one dict
+    cannot stall override reads on unrelated ones. The lock is held across
+    the resolution itself and is RE-ENTRANT (see ``_OverridesLock``), so a
+    producer may read other overridden attributes backed by the same dict
+    from its own thread; only a producer that blocks on ANOTHER thread's
+    read of the same dict deadlocks — producers are plain value factories
+    (APF ``lazy_overrides``), not cross-thread Role readers.
+    """
+    holder = ov.get(_OVERRIDES_LOCK_KEY)
+    if holder is None:
+        with _overrides_lock_mint_guard:
+            holder = ov.get(_OVERRIDES_LOCK_KEY)
+            if holder is None:
+                holder = _OverridesLock()
+                ov[_OVERRIDES_LOCK_KEY] = holder
+    return holder.lock
+
+
+class _ResolvedOverride:
+    """Write-back marker wrapping a resolved override value in the (shared)
+    ``overrides`` dict — distinguishes an already-resolved value from an
+    unresolved producer (callable/awaitable), so a resolved value that
+    happens to be callable is never re-invoked."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def __call__(self) -> object:
+        # preserves the legacy memoized-callable contract for consumers that
+        # index the raw dict and invoke the entry (the APF launcher wraps
+        # `overrides.get("image")` and later calls it): post-resolution the
+        # entry is this marker, so calling it returns the resolved value
+        return self.value
+
+
+def _resolve_awaitable_override(attrname: str, value: "Awaitable[object]") -> object:
+    """Blocks until the awaitable override ``value`` resolves, regardless of
+    the thread/event-loop context the attribute access happens in.
+    """
+    get_loop = getattr(value, "get_loop", None)
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    async def _await(aw: "Awaitable[object]") -> object:
+        return await aw
+
+    if running_loop is None:
+        # no event loop running in this thread — safe to block on one
+        if get_loop is not None:
+            # futures/tasks are bound to their creating loop; drive that
+            # loop — or, if it is already running in another thread,
+            # schedule the await on it
+            bound_loop = get_loop()
+            if bound_loop.is_running():
+                return asyncio.run_coroutine_threadsafe(
+                    _await(value), bound_loop
+                ).result()
+            return bound_loop.run_until_complete(value)
+        # plain coroutines are loop-less — drive a fresh loop
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(value)
+        finally:
+            loop.close()
+
+    # called from inside a running event loop, where both
+    # run_until_complete() and asyncio.run() raise RuntimeError
+    if get_loop is None:
+        # plain coroutines are loop-less — resolve on a worker thread
+        # with its own loop
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(lambda: asyncio.run(_await(value))).result()
+
+    # futures/tasks are bound to their creating loop; a fresh loop
+    # awaiting them raises "attached to a different loop"
+    bound_loop = get_loop()
+    if bound_loop is running_loop:
+        # this thread's loop cannot progress while this call blocks on it —
+        # resolving here would deadlock (the caller keeps the override, so it
+        # can still be awaited)
+        raise RuntimeError(
+            f"override `{attrname}` is bound to the event loop"
+            " currently running in this thread; `await` it"
+            " instead of accessing the attribute synchronously"
+        )
+    if bound_loop.is_running():
+        # completed by its own (other-thread) loop; best-effort check — a loop
+        # stopping between the check and the call is the caller's race to lose
+        return asyncio.run_coroutine_threadsafe(_await(value), bound_loop).result()
+    # bound loop is idle — drive it from a worker thread
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(bound_loop.run_until_complete, value).result()
+
+
 @dataclass
 class Role:
     """
@@ -464,7 +616,10 @@ class Role:
     mounts: list[BindMount | VolumeMount | DeviceMount] = field(default_factory=list)
     workspace: Workspace | None = None
 
-    # DEPRECATED DO NOT SET, WILL BE REMOVED SOON
+    # Deprecated — do not set. Kept while the APF launcher still produces
+    # lazy overrides at runtime (apf/launcher/torchx_utils.py sets
+    # `role.overrides` from `PkgInfo.lazy_overrides`); removal tracked in
+    # T237753541.
     overrides: dict[str, Any] = field(default_factory=dict)
 
     # pyre-ignore
@@ -475,17 +630,30 @@ class Role:
             ov = super().__getattribute__("overrides")
         except AttributeError:
             ov = {}
-        if attrname in ov:
-            if inspect.isawaitable(ov[attrname]):
-                try:
-                    loop = asyncio.get_event_loop()
-                    result = loop.run_until_complete(ov[attrname])
-                except RuntimeError:
-                    result = asyncio.run(ov[attrname])
-            else:
-                result = ov[attrname]()
-            setattr(self, attrname, result)
-            ov[attrname] = lambda: result
+        # lock-free fast path: keys are never removed (resolution writes back
+        # in place) and the write-back is an atomic reference assignment, so
+        # this unlocked read is stable — already-resolved overrides return
+        # without touching the resolution lock
+        value = ov.get(attrname, _NO_OVERRIDE)
+        if isinstance(value, _ResolvedOverride):
+            return value.value
+        if value is not _NO_OVERRIDE:
+            # single-flight read-resolve-writeback: concurrent readers of the
+            # same attribute run the producer exactly once
+            with _overrides_resolution_lock(ov):
+                value = ov[attrname]
+                if isinstance(value, _ResolvedOverride):
+                    return value.value
+                # on failure the producer stays in the dict untouched —
+                # nothing is popped before success
+                if inspect.isawaitable(value):
+                    result = _resolve_awaitable_override(attrname, value)
+                else:
+                    result = value()
+                # write back into the (possibly shared) dict: every role
+                # sharing this dict sees the resolved value
+                ov[attrname] = _ResolvedOverride(result)
+                return result
         return super().__getattribute__(attrname)
 
     def pre_proc(
@@ -668,7 +836,9 @@ class AppStatus:
             raise AppStatusError(self, f"job did not succeed: {self}")
 
     def _format_error_message(self, msg: str, header: str, width: int = 80) -> str:
-        assert len(header) < width
+        assert (
+            len(header) < width
+        ), f"header {header!r} (len {len(header)}) must be shorter than width {width}"
 
         match = re.search(_RPC_ERROR_MESSAGE_RE, msg)
         if match:
@@ -1252,8 +1422,6 @@ def parse_app_handle(app_handle: AppHandle) -> ParsedAppHandle:
 
     # parse it manually b/c currently torchx does not
     # define allowed characters nor length for session name and app_id
-    import re
-
     pattern = r"(?P<scheduler_backend>.+)://(?P<session_name>.*)/(?P<app_id>.+)"
     match = re.match(pattern, app_handle)
     if not match:

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -9,8 +9,10 @@
 
 import asyncio
 import concurrent
+import copy
 import os
 import tempfile
+import threading
 import time
 import unittest
 from dataclasses import asdict
@@ -21,6 +23,8 @@ from unittest.mock import MagicMock
 
 from torchx.specs import named_resources, named_resources_aws, resource
 from torchx.specs.api import (
+    _OVERRIDES_LOCK_KEY,
+    _OverridesLock,
     _TERMINAL_STATES,
     AppDef,
     AppDryRunInfo,
@@ -446,6 +450,40 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual(new_resource.capabilities["new_key"], "new_value")
         self.assertEqual(resource.capabilities["test_key"], "test_value")
 
+    def test_copy_resource_copies_devices_and_tags(self) -> None:
+        resource = Resource(
+            1,
+            2,
+            3,
+            devices={"vpc.amazonaws.com/efa": 4},
+            tags={"resource_name": "test"},
+        )
+        new_resource = Resource.copy(resource)
+
+        self.assertEqual(
+            new_resource.devices,
+            {"vpc.amazonaws.com/efa": 4},
+            "copy must carry the original's devices",
+        )
+        self.assertEqual(
+            new_resource.tags,
+            {"resource_name": "test"},
+            "copy must carry the original's tags",
+        )
+
+        new_resource.devices["nvidia.com/gpu"] = 1
+        new_resource.tags["extra"] = "x"
+        self.assertEqual(
+            resource.devices,
+            {"vpc.amazonaws.com/efa": 4},
+            "mutating the copy's devices must not leak into the original",
+        )
+        self.assertEqual(
+            resource.tags,
+            {"resource_name": "test"},
+            "mutating the copy's tags must not leak into the original",
+        )
+
     def test_is_fractional_default(self) -> None:
         """Resource with no tags is not fractional."""
         res = Resource(cpu=4, gpu=1, memMB=1024)
@@ -623,6 +661,266 @@ class RoleBuilderTest(unittest.TestCase):
         )
         self.assertEqual("base", default.image)
         self.assertEqual("nentry", default.entrypoint)
+
+    def test_override_role_resolved_in_place(self) -> None:
+        calls = 0
+
+        def produce() -> str:
+            nonlocal calls
+            calls += 1
+            return "base"
+
+        default = Role(
+            "foobar",
+            "torch",
+            overrides={"image": produce},
+        )
+        self.assertEqual("base", default.image)
+        self.assertEqual("base", default.image, "the resolved value must persist")
+        self.assertEqual(1, calls, "the producer must run exactly once")
+        self.assertIn(
+            "image",
+            default.overrides,
+            "resolution writes back in place — the key must stay in `overrides`",
+        )
+
+    def test_override_role_single_flight_under_concurrency(self) -> None:
+        calls = 0
+
+        def produce() -> str:
+            nonlocal calls
+            calls += 1
+            time.sleep(0.05)  # widen the race window
+            return "base"
+
+        role = Role("foobar", "torch", overrides={"image": produce})
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda _: role.image, range(8)))
+        self.assertEqual(["base"] * 8, results)
+        self.assertEqual(
+            1, calls, "concurrent readers must resolve the override exactly once"
+        )
+
+    def test_override_single_flight_across_roles_sharing_dict(self) -> None:
+        calls = 0
+
+        def produce() -> str:
+            nonlocal calls
+            calls += 1
+            time.sleep(0.05)  # widen the race window
+            return "base"
+
+        overrides: dict[str, object] = {"image": produce}
+        role_a = Role("a", "torch", overrides=overrides)
+        role_b = Role("b", "torch", overrides=overrides)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(
+                pool.map(lambda i: (role_a if i % 2 else role_b).image, range(8))
+            )
+        self.assertEqual(["base"] * 8, results)
+        self.assertEqual(
+            1,
+            calls,
+            "roles sharing an overrides dict must share its single-flight lock",
+        )
+
+    def test_override_resolution_not_serialized_across_dicts(self) -> None:
+        producer_entered: threading.Event = threading.Event()
+        release_producer: threading.Event = threading.Event()
+
+        def slow_produce() -> str:
+            producer_entered.set()
+            assert release_producer.wait(timeout=30), "watchdog: test never released"
+            return "slow"
+
+        slow_role = Role("slow", "torch", overrides={"image": slow_produce})
+        fast_role = Role("fast", "torch", overrides={"image": lambda: "fast"})
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            slow_read = pool.submit(lambda: slow_role.image)
+            self.assertTrue(
+                producer_entered.wait(timeout=30),
+                "watchdog: slow producer never started",
+            )
+            try:
+                # bounded read: under a process-wide resolution lock this
+                # blocks behind the (still-running) slow producer and times out
+                fast_read = pool.submit(lambda: fast_role.image)
+                self.assertEqual(
+                    "fast",
+                    fast_read.result(timeout=10),
+                    "one dict's slow producer must not stall reads on another",
+                )
+            finally:
+                release_producer.set()
+            self.assertEqual("slow", slow_read.result(timeout=30))
+
+    def test_override_producer_rereads_same_role(self) -> None:
+        overrides: dict[str, object] = {"entrypoint": lambda: "nentry"}
+        role = Role("foobar", "torch", overrides=overrides)
+        # the producer reads another overridden attr on the same role,
+        # re-entering the same dict's resolution lock on its own thread
+        overrides["image"] = lambda: f"{role.entrypoint}-img"
+        # daemon thread (not a pool): on deadlock the join times out and the
+        # test fails instead of hanging the process on worker shutdown
+        result: list[str] = []
+        reader = threading.Thread(target=lambda: result.append(role.image))
+        reader.daemon = True
+        reader.start()
+        reader.join(timeout=30)
+        self.assertEqual(
+            ["nentry-img"],
+            result,
+            "a producer reading an overridden attr on the same role must"
+            " not self-deadlock (resolution lock is re-entrant)",
+        )
+        self.assertEqual("nentry", role.entrypoint)
+
+    def test_resolved_override_dict_entry_remains_callable(self) -> None:
+        role = Role("foobar", "torch", overrides={"image": lambda: "base"})
+        self.assertEqual("base", role.image)  # resolves + writes back
+        self.assertEqual(
+            "base",
+            role.overrides["image"](),
+            "raw-dict consumers invoke the memoized entry post-resolution"
+            " (legacy callable contract)",
+        )
+
+    def test_override_resolved_read_skips_resolution_lock(self) -> None:
+        role = Role("foobar", "torch", overrides={"image": lambda: "base"})
+        self.assertEqual("base", role.image)  # resolves + mints the dict's lock
+
+        class FailingLock:
+            def __enter__(self) -> None:
+                raise AssertionError(
+                    "a resolved override read must not take the resolution lock"
+                )
+
+            def __exit__(self, *exc: object) -> None:
+                pass
+
+        role.overrides[_OVERRIDES_LOCK_KEY].lock = FailingLock()
+        self.assertEqual("base", role.image, "fast path must serve resolved values")
+        self.assertEqual("foobar", role.name, "non-overridden reads must not lock")
+
+    def test_role_with_resolved_overrides_deepcopies(self) -> None:
+        role = Role("foobar", "torch", overrides={"image": lambda: "base"})
+        self.assertEqual("base", role.image)  # resolves + mints the dict's lock
+        clone = copy.deepcopy(role)
+        self.assertEqual(
+            "base",
+            clone.image,
+            "a role with a minted resolution lock must stay deep-copyable",
+        )
+
+    def test_async_override_role_inside_running_loop(self) -> None:
+        async def update(value: str) -> str:
+            await asyncio.sleep(0)
+            return value
+
+        async def resolve_image() -> str:
+            role = Role(
+                "foobar",
+                "torch",
+                overrides={"image": update("base")},
+            )
+            return role.image
+
+        self.assertEqual(
+            "base",
+            asyncio.run(resolve_image()),
+            "awaitable overrides must resolve when accessed inside a running event loop",
+        )
+
+    def test_override_role_failed_resolution_keeps_override(self) -> None:
+        def boom() -> str:
+            raise RuntimeError("boom")
+
+        role = Role("foobar", "torch", overrides={"image": boom})
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            _ = role.image
+        self.assertIs(
+            boom,
+            role.overrides.get("image"),
+            "a failed resolution must leave the producer in `overrides` for retry",
+        )
+
+    def test_override_role_future_bound_to_other_running_loop(self) -> None:
+        owner_loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=owner_loop.run_forever, daemon=True)
+        thread.start()
+        try:
+
+            async def make_future() -> "asyncio.Future[str]":
+                loop = asyncio.get_running_loop()
+                fut: "asyncio.Future[str]" = loop.create_future()
+                loop.call_later(0.05, fut.set_result, "base")
+                return fut
+
+            fut: "asyncio.Future[str]" = asyncio.run_coroutine_threadsafe(
+                make_future(), owner_loop
+            ).result()
+
+            async def resolve_image() -> str:
+                role = Role("foobar", "torch", overrides={"image": fut})
+                return role.image
+
+            self.assertEqual(
+                "base",
+                asyncio.run(resolve_image()),
+                "a future bound to another thread's running loop must resolve"
+                " when accessed inside this thread's running loop",
+            )
+        finally:
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            thread.join(timeout=5)
+            owner_loop.close()
+
+    def test_override_role_future_bound_to_other_running_loop_no_local_loop(
+        self,
+    ) -> None:
+        owner_loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=owner_loop.run_forever, daemon=True)
+        thread.start()
+        try:
+
+            async def make_future() -> "asyncio.Future[str]":
+                loop = asyncio.get_running_loop()
+                fut: "asyncio.Future[str]" = loop.create_future()
+                loop.call_later(0.05, fut.set_result, "base")
+                return fut
+
+            fut: "asyncio.Future[str]" = asyncio.run_coroutine_threadsafe(
+                make_future(), owner_loop
+            ).result()
+            role = Role("foobar", "torch", overrides={"image": fut})
+            self.assertEqual(
+                "base",
+                role.image,
+                "a future bound to another thread's running loop must resolve"
+                " from a thread with no loop of its own",
+            )
+        finally:
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            thread.join(timeout=5)
+            owner_loop.close()
+
+    def test_override_role_future_bound_to_current_loop_raises(self) -> None:
+        async def resolve_image() -> None:
+            fut: "asyncio.Future[str]" = asyncio.get_running_loop().create_future()
+            role = Role("foobar", "torch", overrides={"image": fut})
+            with self.assertRaisesRegex(
+                RuntimeError, "currently running in this thread"
+            ):
+                _ = role.image
+            self.assertIs(
+                fut,
+                role.overrides.get("image"),
+                "an unresolvable loop-bound override must stay in `overrides`"
+                " so the caller can still `await` it",
+            )
+
+        asyncio.run(resolve_image())
 
     def test_concurrent_override_role(self) -> None:
 
@@ -1088,6 +1386,68 @@ class MacrosTest(unittest.TestCase):
         self.assertNotEqual(newrole, role)
         self.assertEqual(newrole.args, ["img_root"])
         self.assertEqual(newrole.env, {"FOO": "app_id"})
+
+    def test_apply_preserves_role_overrides(self) -> None:
+        overrides = {"entrypoint": lambda: "lazy.py"}
+        role = Role(
+            name="test",
+            image="test_image",
+            args=[macros.img_root],
+            overrides=overrides,
+        )
+        v = macros.Values(
+            img_root="img_root",
+            app_id="app_id",
+            replica_id="replica_id",
+            rank0_env="rank0_env",
+        )
+        newrole = v.apply(role)
+        self.assertIs(
+            role.overrides,
+            overrides,
+            "apply() must restore the caller role's overrides",
+        )
+        self.assertIs(
+            newrole.overrides,
+            overrides,
+            "the copy shares the dict — write-back resolution makes either"
+            " owner's resolution visible to both",
+        )
+        self.assertEqual("lazy.py", newrole.entrypoint)
+        self.assertEqual(
+            "lazy.py",
+            role.entrypoint,
+            "resolving on the copy must resolve for the original too",
+        )
+        self.assertEqual(newrole.args, ["img_root"])
+
+    def test_apply_without_overrides_gives_copy_its_own_dict(self) -> None:
+        v = macros.Values(
+            img_root="img_root",
+            app_id="app_id",
+            replica_id="replica_id",
+            rank0_env="rank0_env",
+        )
+
+        role = Role(name="test", image="test_image")
+        with self.assertNoLogs("torchx.specs.api", level="DEBUG"):
+            newrole = v.apply(role)
+        self.assertIsNot(
+            newrole.overrides,
+            role.overrides,
+            "with nothing to share the copy must get its own overrides dict",
+        )
+
+        # the reserved lock-key entry alone must not read as "has overrides"
+        locked = Role(name="test", image="test_image")
+        locked.overrides[_OVERRIDES_LOCK_KEY] = _OverridesLock()
+        with self.assertNoLogs("torchx.specs.api", level="DEBUG"):
+            newlocked = v.apply(locked)
+        self.assertIsNot(
+            newlocked.overrides,
+            locked.overrides,
+            "a lock-key-only dict counts as empty — no sharing",
+        )
 
     def test_apply_nested_with_list_of_dicts(self) -> None:
         """Test that _apply_nested correctly handles dictionaries nested inside lists."""


### PR DESCRIPTION
Summary:

Four behavior fixes in the specs/runner data model:

1. `macros.Values.apply` stripped the caller `Role`'s `overrides` (detached around the deepcopy, reattached only to the copy). Now restored and shared with the copy by reference (write-back resolution keeps single-shot producers once-only); with no real overrides the copy gets its own dict.
2. `Resource.copy` dropped `tags` and passed `devices` by reference; both are dict-copied now.
3. Awaitable `Role.overrides` could not resolve inside a running event loop. `_resolve_awaitable_override` now handles every thread × loop × bound-future case (mechanics in its docstring); only a future bound to the current thread's running loop refuses (`await` it instead).
4. `Runner._scheduler` on an unknown backend raised a bare `KeyError`; it now raises the existing — but never raised — `UnknownSchedulerException`.

**Resolution concurrency:** single-flight is per overrides dict — the lock lives under a reserved non-identifier key inside the dict, so dict-sharing copies share the lock and one dict's slow producer cannot stall unrelated `Role`s. The lock is re-entrant: a producer reading another overridden attr on the same `Role` resolves it instead of self-deadlocking. Resolved reads are lock-free; the write-back marker is callable, preserving the legacy memoized-callable contract for raw-dict consumers (APF invokes `overrides.get("image")`).

Riders: module logger (was root-logger masquerade); `import re` hoisted; assert message added; `Role.overrides` deprecation comment names the removal blocker (APF `lazy_overrides`, T237753541).

Differential Revision: D116021587


