### PR TITLE
(feature)[1/7][torchx][specs] Public app/cfg accessors on AppDryRunInfo (#1381)

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -302,7 +302,7 @@ class CmdRun(SubCommand):
                 print(
                     # pyrefly: ignore [bad-argument-type]
                     "\n=== APPLICATION ===\n"
-                    f"{pformat(asdict(dryrun_info._app), indent=2, width=80)}"
+                    f"{pformat(asdict(dryrun_info.app), indent=2, width=80)}"
                 )
 
                 print("\n=== SCHEDULER REQUEST ===\n" f"{dryrun_info}")

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -181,7 +181,7 @@ class Runner:
                 parent_run_id=parent_run_id,
             )
             handle = self.schedule(dryrun_info)
-            app = none_throws(dryrun_info._app)
+            app = none_throws(dryrun_info.app)
 
             ctx._torchx_event.workspace = str(workspace)
             ctx._torchx_event.scheduler = none_throws(dryrun_info._scheduler)
@@ -288,7 +288,7 @@ class Runner:
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.workspace = str(workspace)
             event.app_id = parse_app_handle(handle)[2]
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return handle
@@ -306,20 +306,20 @@ class Runner:
                      cause your usage to diverge from TorchX's supported API.
         """
         scheduler = none_throws(dryrun_info._scheduler)
-        cfg = dryrun_info._cfg
+        cfg = dryrun_info.cfg
         with log_event("schedule") as ctx:
             sched = self._scheduler(scheduler)
             app_id = sched.schedule(dryrun_info)
             app_handle = make_app_handle(scheduler, self._name, app_id)
 
-            app = none_throws(dryrun_info._app)
+            app = none_throws(dryrun_info.app)
             self._apps[app_handle] = app
 
             event = ctx._torchx_event
             event.scheduler = scheduler
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.app_id = app_id
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return app_handle
@@ -430,7 +430,7 @@ class Runner:
             event.scheduler = scheduler
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.app_id = app.name
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return dryrun_info

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -790,9 +790,7 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
     def schedule(self, dryrun_info: AppDryRunInfo[KubernetesJob]) -> str:
         from kubernetes.client.rest import ApiException
 
-        cfg = dryrun_info._cfg
-        assert cfg is not None, f"{dryrun_info} missing cfg"
-        namespace = cfg.get("namespace") or "default"
+        namespace = dryrun_info.cfg.get("namespace") or "default"
 
         images_to_push = dryrun_info.request.images_to_push
         self.push_images(images_to_push)

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -46,7 +46,7 @@ class SchedulerTest(unittest.TestCase):
             super().__init__("mock", session_name)
 
         def schedule(self, dryrun_info: AppDryRunInfo[None]) -> str:
-            app = dryrun_info._app
+            app = dryrun_info.app
             assert app is not None
             return app.name
 
@@ -120,6 +120,22 @@ class SchedulerTest(unittest.TestCase):
         cfg = {"foo": "asdf"}
         scheduler_mock.submit(app, cfg, workspace="some_workspace")
         self.assertEqual(app.roles[0].image, "some_workspace")
+
+    def test_submit_dryrun_sets_app_and_cfg(self) -> None:
+        app = AppDef(
+            name="test_app",
+            roles=[Role(name="sleep", image="", entrypoint="foo.sh")],
+        )
+        scheduler = SchedulerTest.MockScheduler("test_session")
+
+        dryrun_info = scheduler.submit_dryrun(app, {"foo": "asdf"})
+
+        self.assertIs(app, dryrun_info.app, "app should be the submitted AppDef")
+        self.assertEqual(
+            scheduler.run_opts().resolve({"foo": "asdf"}),
+            dict(dryrun_info.cfg),
+            "cfg should equal the resolved run cfg",
+        )
 
     def test_metadata_macro_substitute(self) -> None:
         role = Role(

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from enum import Enum
 from json import JSONDecodeError
 from string import Template
+from types import MappingProxyType
 from typing import (
     Any,
     Callable,
@@ -828,17 +829,30 @@ class AppDryRunInfo(Generic[T]):
         self.request = request
         self._fmt = fmt
 
-        # fields below are only meant to be used by
-        # Scheduler or Session implementations
-        # and are back references to the parameters
-        # to dryrun() that returned this AppDryRunInfo object
-        # thus they are set in Runner.dryrun() and Scheduler.submit_dryrun()
-        # manually rather than through constructor arguments
-        # DO NOT create getters or make these public
-        # unless there is a good reason to
+        # back references to the parameters of the dryrun() call that
+        # returned this AppDryRunInfo object; set in Runner.dryrun() and
+        # Scheduler.submit_dryrun() manually rather than through constructor
+        # arguments. Read them via the `app` and `cfg` properties;
+        # `_scheduler` is only meant for Scheduler/Runner implementations.
         self._app: AppDef | None = None
         self._cfg: Mapping[str, CfgVal] = {}
         self._scheduler: str | None = None
+
+    @property
+    def app(self) -> AppDef | None:
+        """The :py:class:`AppDef` this dryrun info was created from.
+
+        ``None`` until set by ``Runner.dryrun()`` / ``Scheduler.submit_dryrun()``.
+        """
+        return self._app
+
+    @property
+    def cfg(self) -> Mapping[str, CfgVal]:
+        """Read-only view of the resolved scheduler run config.
+
+        Mutating the returned mapping raises ``TypeError``.
+        """
+        return MappingProxyType(self._cfg)
 
     def __repr__(self) -> str:
         return self._fmt(self.request)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -15,7 +15,7 @@ import time
 import unittest
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, List, Mapping, Union
+from typing import cast, Dict, List, Mapping, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -182,6 +182,33 @@ class AppDryRunInfoTest(unittest.TestCase):
         self.assertEqual(request_mock, info.request)
 
         to_string_mock.assert_called_once_with(request_mock)
+
+    def test_app_and_cfg_accessors(self) -> None:
+        info = AppDryRunInfo(MagicMock(), repr)
+
+        self.assertIsNone(info.app, "app should be None until set by dryrun")
+        self.assertEqual({}, dict(info.cfg), "cfg should default to empty")
+
+        app = AppDef(name="test_app")
+        info._app = app
+        info._cfg = {"cluster": "foo", "priority": 1}
+
+        self.assertIs(app, info.app, "app property should return the AppDef")
+        self.assertEqual(
+            {"cluster": "foo", "priority": 1},
+            dict(info.cfg),
+            "cfg property should reflect the resolved cfg",
+        )
+
+    def test_cfg_is_read_only(self) -> None:
+        info = AppDryRunInfo(MagicMock(), repr)
+        info._cfg = {"cluster": "foo"}
+
+        # cast defeats the static Mapping protocol (no `__setitem__`) so the
+        # RUNTIME read-only guarantee (MappingProxyType) is what's exercised
+        cfg = cast(dict[str, CfgVal], info.cfg)
+        with self.assertRaises(TypeError, msg="mutating cfg view must raise"):
+            cfg["cluster"] = "bar"
 
 
 class AppDefStatusTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

`AppDryRunInfo` now exposes the dryrun's `AppDef` and resolved run cfg as public read-only properties, so schedulers and tooling no longer reach into the `_app`/`_cfg` privates.

```python
info = runner.dryrun(app, "kubernetes", cfg=cfg)
info.app             # the AppDef the dryrun was built from
info.cfg             # read-only view of the resolved cfg
info.cfg["x"] = "y"  # TypeError: mappingproxy is immutable
```

- `cfg` returns `MappingProxyType(self._cfg)` — same resolved-cfg contract (populated by `Scheduler.submit_dryrun`), but callers can no longer mutate it.
- `_scheduler` stays private: runner-internal plumbing, not a consumer surface.
- All in-tree readers migrate off the privates (core: `runner/api.py`, `kubernetes_scheduler.py`, `schedulers/test/api_test.py`; fb: mast/msl/hpc/rmuc schedulers, `orchestrator_runner.py`, CLI, jetter example). Writes in `Scheduler.submit_dryrun` and test fixtures keep setting the private fields — the properties are read-only by design.
- The stale "DO NOT create getters" comment is rewritten, and `kubernetes_scheduler.schedule` drops an `assert cfg is not None` that was already impossible (`_cfg` defaults to `{}`).

**TBD fork plan:** the fb-file edits are read-side only (no written values change), and `_app`/`_cfg` remain beneath the new properties, so the fork (`genai/msl/torchx_plugins`) is unaffected today. Migrating the fork to the public `.app`/`.cfg` is the planned plugin-side follow-on, gated on the torchx-nightly pickup of this stack.

Differential Revision: D116126083
