### PR TITLE
(feature)[2/7][torchx][plugins] Add PluginRegistry.load_errors() diagnostics (#1383)

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -5,6 +5,7 @@
     ".*/setup.py",
     ".*/IPython/core/tests/nonascii.*",
     ".*/torchx/examples/apps/compute_world_size/.*",
+    ".*/torchx/plugins/test/broken_root/.*",
     ".*/site-packages/sagemaker/.*"
   ],
   "ignore_all_errors": [

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -10,9 +10,12 @@ Core API
 .. autofunction:: torchx.plugins.registry
 
 .. autoclass:: torchx.plugins.PluginRegistry
-   :members: get, info
+   :members: get, info, errors, load_errors
 
 .. autoclass:: torchx.plugins.PluginType
+   :members:
+
+.. autoclass:: torchx.plugins.RegistrationError
    :members:
 
 Registration

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -302,7 +302,7 @@ class CmdRun(SubCommand):
                 print(
                     # pyrefly: ignore [bad-argument-type]
                     "\n=== APPLICATION ===\n"
-                    f"{pformat(asdict(dryrun_info._app), indent=2, width=80)}"
+                    f"{pformat(asdict(dryrun_info.app), indent=2, width=80)}"
                 )
 
                 print("\n=== SCHEDULER REQUEST ===\n" f"{dryrun_info}")

--- a/torchx/plugins/_registry.py
+++ b/torchx/plugins/_registry.py
@@ -292,10 +292,30 @@ class PluginRegistry:
         namespace: str,
         expected_type: PluginType | None = None,
     ) -> dict[str, Any]:
-        """Scan a namespace package for ``@register``-decorated plugins."""
+        """Scan a namespace package for ``@register``-decorated plugins.
+
+        A ``ModuleNotFoundError`` for *namespace* itself (or a parent) means
+        the namespace package is simply not installed — an empty registry,
+        not an error. Any other exception raised while importing the root
+        namespace (broken ``__init__``, missing dependency) is recorded as a
+        :py:class:`RegistrationError`.
+        """
         try:
             pkg: ModuleType = importlib.import_module(namespace)
-        except ImportError:
+        except ModuleNotFoundError as e:
+            missing = e.name
+            if missing and (
+                namespace == missing or namespace.startswith(f"{missing}.")
+            ):
+                return {}
+            msg = f"{type(e).__name__}: {e}"
+            logger.warning("failed to import namespace `%s`: %s", namespace, e)
+            self._errors.append(RegistrationError(module=namespace, error=msg))
+            return {}
+        except Exception as e:
+            msg = f"{type(e).__name__}: {e}"
+            logger.warning("failed to import namespace `%s`: %s", namespace, e)
+            self._errors.append(RegistrationError(module=namespace, error=msg))
             return {}
 
         if not hasattr(pkg, "__path__"):
@@ -369,8 +389,67 @@ class PluginRegistry:
 
     @property
     def errors(self) -> list[RegistrationError]:
-        """Errors encountered during plugin discovery."""
+        """Errors recorded by discovery that has already run.
+
+        A passive read with no side effects — groups that were never
+        :py:meth:`get`-ed contribute nothing here (an empty list does not
+        mean "no broken plugins"). Use :py:meth:`load_errors` to force
+        discovery before reading.
+        """
         return list(self._errors)
+
+    def load_errors(
+        self, plugin_type: PluginType | None = None
+    ) -> list[RegistrationError]:
+        """Force discovery, then return the errors it recorded.
+
+        Unlike the :py:attr:`errors` property, this first triggers discovery
+        for *plugin_type* (all groups when ``None``) via :py:meth:`get`, so
+        broken plugins are reported even before anything explicitly asked
+        for them.
+
+        The recorded set (import-level entries carry ``name=None``):
+
+        - **root-namespace import failure** — ``torchx_plugins.<group>``
+          exists but raises on import (e.g. a ``ModuleNotFoundError`` for a
+          missing dependency raised from its ``__init__``). A plain
+          "namespace not installed" ``ModuleNotFoundError`` for the
+          namespace itself is not recorded — that is the empty registry.
+        - **submodule import failure** — a plugin module inside the
+          namespace raises on import.
+        - **scan failure** — ``pkgutil.iter_modules`` fails on a namespace
+          path.
+        - **type mismatch** — a plugin registered under the wrong namespace
+          group (recorded with its *actual* ``plugin_type``).
+        - **duplicate name** — two plugins register the same name (first
+          occurrence wins).
+
+        When *plugin_type* is given, returns the errors recorded under that
+        group's namespace plus plugin-level errors tagged with that type —
+        a type-mismatch error therefore matches both the group it was found
+        under and the group it belongs to.
+        """
+        # __members__.values() over list(PluginType): OSS pyre cannot iterate
+        # Type[Enum] directly (equivalent while PluginType has no aliases)
+        plugin_types: list[PluginType] = (
+            [plugin_type]
+            if plugin_type is not None
+            else list(PluginType.__members__.values())
+        )
+        for pt in plugin_types:
+            self.get(pt)
+
+        if plugin_type is None:
+            return list(self._errors)
+
+        namespace = self._namespace_for_type(plugin_type)
+        return [
+            err
+            for err in self._errors
+            if err.plugin_type == plugin_type.name.lower()
+            or err.module == namespace
+            or err.module.startswith(f"{namespace}.")
+        ]
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize all discovered plugins to a plain dict.

--- a/torchx/plugins/test/broken_root/torchx_plugins/schedulers/__init__.py
+++ b/torchx/plugins/test/broken_root/torchx_plugins/schedulers/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Broken root-namespace fixture: importing ``torchx_plugins.schedulers``
+itself fails with a ``ModuleNotFoundError`` for a missing dependency.
+
+Simulates a plugin distribution that (incorrectly) ships an ``__init__.py``
+whose body raises — distinct from the "namespace not installed" case.
+"""
+
+import missing_scheduler_dep  # noqa: F401

--- a/torchx/plugins/test/registry_test.py
+++ b/torchx/plugins/test/registry_test.py
@@ -49,6 +49,11 @@ _TEST_PLUGINS_DIRS: list[str] = [
     str(_TEST_DIR / "bad"),
 ]
 
+# Used ALONE (never merged with the dirs above): its torchx_plugins/schedulers
+# is a regular package whose __init__.py raises, which would shadow the
+# PEP 420 namespace merging of the healthy fixture dirs.
+_BROKEN_ROOT_DIR: str = str(_TEST_DIR / "broken_root")
+
 
 def mock_install_torchx_plugins() -> Any:  # pyre-ignore[3]: returns mock._patch
     """Mock-install the test ``torchx_plugins`` namespace package.
@@ -641,6 +646,91 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
             )
         finally:
             sys.modules.pop("torchx_plugins.schedulers.conflict", None)
+
+    @mock_install_torchx_plugins()
+    def test_errors_property_is_passive(self) -> None:
+        """errors returns nothing before discovery ran — no side effects."""
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        self.assertEqual(
+            [],
+            reg.errors,
+            "errors property must not trigger discovery",
+        )
+
+    @mock_install_torchx_plugins()
+    def test_load_errors_forces_discovery(self) -> None:
+        """load_errors() reports planted broken modules before any get()."""
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+
+        error_modules = {e.module for e in reg.load_errors()}
+
+        self.assertIn(
+            "torchx_plugins.schedulers.airflow",
+            error_modules,
+            "load_errors() should trigger discovery and report airflow.py",
+        )
+        self.assertIn(
+            "torchx_plugins.schedulers.ray",
+            error_modules,
+            "load_errors() should trigger discovery and report ray.py",
+        )
+
+    @mock_install_torchx_plugins()
+    def test_load_errors_group_filtering(self) -> None:
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+
+        sched_errors = reg.load_errors(PluginType.SCHEDULER)
+        self.assertIn(
+            "torchx_plugins.schedulers.ray",
+            {e.module for e in sched_errors},
+            "scheduler-namespace import errors should match SCHEDULER",
+        )
+
+        self.assertEqual(
+            [],
+            reg.load_errors(PluginType.NAMED_RESOURCE),
+            "named_resource group has no broken fixtures",
+        )
+
+        # mlflow is a tracker mis-registered under schedulers/ — it matches
+        # TRACKER via its plugin_type tag.
+        tracker_errors = reg.load_errors(PluginType.TRACKER)
+        self.assertIn(
+            "mlflow",
+            {e.name for e in tracker_errors},
+            "type-mismatch errors should match their actual plugin type",
+        )
+
+    def test_load_errors_root_namespace_failure(self) -> None:
+        """A root namespace whose __init__ raises MNFE for a missing dep is recorded."""
+        with patch("sys.path", [_BROKEN_ROOT_DIR, *sys.path]):
+            reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+            errors = reg.load_errors(PluginType.SCHEDULER)
+
+        root_errors = [e for e in errors if e.module == "torchx_plugins.schedulers"]
+        self.assertEqual(
+            1,
+            len(root_errors),
+            f"root-namespace import failure should be recorded, got: {errors}",
+        )
+        self.assertIsNone(
+            root_errors[0].name,
+            "import-level errors should carry name=None",
+        )
+        self.assertIn(
+            "missing_scheduler_dep",
+            root_errors[0].error,
+            "the missing dependency should be named in the error",
+        )
+
+    def test_load_errors_namespace_not_installed_is_clean(self) -> None:
+        """A plain 'not installed' namespace is an empty registry, not an error."""
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        self.assertEqual(
+            [],
+            reg.load_errors(),
+            "missing torchx_plugins namespace must not be recorded as an error",
+        )
 
     def test_broken_path_in_iter_modules_is_caught(self) -> None:
         """A broken __path__ that causes pkgutil.iter_modules to fail is caught.

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -181,7 +181,7 @@ class Runner:
                 parent_run_id=parent_run_id,
             )
             handle = self.schedule(dryrun_info)
-            app = none_throws(dryrun_info._app)
+            app = none_throws(dryrun_info.app)
 
             ctx._torchx_event.workspace = str(workspace)
             ctx._torchx_event.scheduler = none_throws(dryrun_info._scheduler)
@@ -288,7 +288,7 @@ class Runner:
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.workspace = str(workspace)
             event.app_id = parse_app_handle(handle)[2]
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return handle
@@ -306,20 +306,20 @@ class Runner:
                      cause your usage to diverge from TorchX's supported API.
         """
         scheduler = none_throws(dryrun_info._scheduler)
-        cfg = dryrun_info._cfg
+        cfg = dryrun_info.cfg
         with log_event("schedule") as ctx:
             sched = self._scheduler(scheduler)
             app_id = sched.schedule(dryrun_info)
             app_handle = make_app_handle(scheduler, self._name, app_id)
 
-            app = none_throws(dryrun_info._app)
+            app = none_throws(dryrun_info.app)
             self._apps[app_handle] = app
 
             event = ctx._torchx_event
             event.scheduler = scheduler
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.app_id = app_id
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return app_handle
@@ -430,7 +430,7 @@ class Runner:
             event.scheduler = scheduler
             event.runcfg = json.dumps(dict(cfg)) if cfg else None
             event.app_id = app.name
-            event.app_image = none_throws(dryrun_info._app).roles[0].image
+            event.app_image = none_throws(dryrun_info.app).roles[0].image
             event.app_metadata = app.metadata
 
             return dryrun_info

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -790,9 +790,7 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
     def schedule(self, dryrun_info: AppDryRunInfo[KubernetesJob]) -> str:
         from kubernetes.client.rest import ApiException
 
-        cfg = dryrun_info._cfg
-        assert cfg is not None, f"{dryrun_info} missing cfg"
-        namespace = cfg.get("namespace") or "default"
+        namespace = dryrun_info.cfg.get("namespace") or "default"
 
         images_to_push = dryrun_info.request.images_to_push
         self.push_images(images_to_push)

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -46,7 +46,7 @@ class SchedulerTest(unittest.TestCase):
             super().__init__("mock", session_name)
 
         def schedule(self, dryrun_info: AppDryRunInfo[None]) -> str:
-            app = dryrun_info._app
+            app = dryrun_info.app
             assert app is not None
             return app.name
 
@@ -120,6 +120,22 @@ class SchedulerTest(unittest.TestCase):
         cfg = {"foo": "asdf"}
         scheduler_mock.submit(app, cfg, workspace="some_workspace")
         self.assertEqual(app.roles[0].image, "some_workspace")
+
+    def test_submit_dryrun_sets_app_and_cfg(self) -> None:
+        app = AppDef(
+            name="test_app",
+            roles=[Role(name="sleep", image="", entrypoint="foo.sh")],
+        )
+        scheduler = SchedulerTest.MockScheduler("test_session")
+
+        dryrun_info = scheduler.submit_dryrun(app, {"foo": "asdf"})
+
+        self.assertIs(app, dryrun_info.app, "app should be the submitted AppDef")
+        self.assertEqual(
+            scheduler.run_opts().resolve({"foo": "asdf"}),
+            dict(dryrun_info.cfg),
+            "cfg should equal the resolved run cfg",
+        )
 
     def test_metadata_macro_substitute(self) -> None:
         role = Role(

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from enum import Enum
 from json import JSONDecodeError
 from string import Template
+from types import MappingProxyType
 from typing import (
     Any,
     Callable,
@@ -828,17 +829,30 @@ class AppDryRunInfo(Generic[T]):
         self.request = request
         self._fmt = fmt
 
-        # fields below are only meant to be used by
-        # Scheduler or Session implementations
-        # and are back references to the parameters
-        # to dryrun() that returned this AppDryRunInfo object
-        # thus they are set in Runner.dryrun() and Scheduler.submit_dryrun()
-        # manually rather than through constructor arguments
-        # DO NOT create getters or make these public
-        # unless there is a good reason to
+        # back references to the parameters of the dryrun() call that
+        # returned this AppDryRunInfo object; set in Runner.dryrun() and
+        # Scheduler.submit_dryrun() manually rather than through constructor
+        # arguments. Read them via the `app` and `cfg` properties;
+        # `_scheduler` is only meant for Scheduler/Runner implementations.
         self._app: AppDef | None = None
         self._cfg: Mapping[str, CfgVal] = {}
         self._scheduler: str | None = None
+
+    @property
+    def app(self) -> AppDef | None:
+        """The :py:class:`AppDef` this dryrun info was created from.
+
+        ``None`` until set by ``Runner.dryrun()`` / ``Scheduler.submit_dryrun()``.
+        """
+        return self._app
+
+    @property
+    def cfg(self) -> Mapping[str, CfgVal]:
+        """Read-only view of the resolved scheduler run config.
+
+        Mutating the returned mapping raises ``TypeError``.
+        """
+        return MappingProxyType(self._cfg)
 
     def __repr__(self) -> str:
         return self._fmt(self.request)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -15,7 +15,7 @@ import time
 import unittest
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, List, Mapping, Union
+from typing import cast, Dict, List, Mapping, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -182,6 +182,33 @@ class AppDryRunInfoTest(unittest.TestCase):
         self.assertEqual(request_mock, info.request)
 
         to_string_mock.assert_called_once_with(request_mock)
+
+    def test_app_and_cfg_accessors(self) -> None:
+        info = AppDryRunInfo(MagicMock(), repr)
+
+        self.assertIsNone(info.app, "app should be None until set by dryrun")
+        self.assertEqual({}, dict(info.cfg), "cfg should default to empty")
+
+        app = AppDef(name="test_app")
+        info._app = app
+        info._cfg = {"cluster": "foo", "priority": 1}
+
+        self.assertIs(app, info.app, "app property should return the AppDef")
+        self.assertEqual(
+            {"cluster": "foo", "priority": 1},
+            dict(info.cfg),
+            "cfg property should reflect the resolved cfg",
+        )
+
+    def test_cfg_is_read_only(self) -> None:
+        info = AppDryRunInfo(MagicMock(), repr)
+        info._cfg = {"cluster": "foo"}
+
+        # cast defeats the static Mapping protocol (no `__setitem__`) so the
+        # RUNTIME read-only guarantee (MappingProxyType) is what's exercised
+        cfg = cast(dict[str, CfgVal], info.cfg)
+        with self.assertRaises(TypeError, msg="mutating cfg view must raise"):
+            cfg["cluster"] = "bar"
 
 
 class AppDefStatusTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

`PluginRegistry.errors` is a passive read — before any `get()` ran it returns `[]`, which **reads as "no broken plugins" even when a planted broken plugin exists**. This diff adds `load_errors(plugin_type=None)`, which forces discovery via `get()` for the requested group(s) before returning the recorded errors, optionally filtered to one group.

```python
from torchx import plugins

# reports broken plugin modules without any prior get() call
errs = plugins.registry().load_errors(plugins.PluginType.SCHEDULER)
```

- The recorded-set contract (root-namespace import failure, submodule import failure, scan failure, type mismatch, duplicate; import-level entries carry `name=None`) is now documented on `load_errors`, with `errors` cross-linked as the no-side-effect read.
- **Rider**: `_find_namespace_plugins` previously swallowed every `ImportError` at the namespace root (silently hiding a broken `torchx_plugins/<group>/__init__.py`) and let any *other* exception crash discovery. It now records both as `RegistrationError`s; only a plain "namespace not installed" `ModuleNotFoundError` (missing module == the namespace or a parent) stays unrecorded — that is the legitimate empty registry.
- Group filtering matches the group's namespace prefix plus plugin-level errors tagged with the type, so a type-mismatch error matches both the group it was found under and the group it belongs to.

Differential Revision: D116126082
