### PR TITLE
(feature)[4/7][torchx][specs] Centralize wire-contract metadata keys (#1384)

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -26,7 +26,7 @@ from torchx.cli.cmd_log import get_logs
 from torchx.runner import config, get_runner, Runner
 from torchx.runner.config import load_sections
 from torchx.schedulers import get_default_scheduler_name, get_scheduler_factories
-from torchx.specs import CfgVal, Workspace
+from torchx.specs import CfgVal, TORCHX_CONTEXT_NAME, Workspace
 from torchx.specs.finder import (
     _Component,
     ComponentNotFoundException,
@@ -444,7 +444,7 @@ class CmdRun(SubCommand):
             self._run_from_cli_args(runner, args)
 
     def run(self, args: argparse.Namespace) -> None:
-        os.environ["TORCHX_CONTEXT_NAME"] = os.getenv("TORCHX_CONTEXT_NAME", "cli_run")
+        os.environ[TORCHX_CONTEXT_NAME] = os.getenv(TORCHX_CONTEXT_NAME, "cli_run")
         component_defaults = load_sections(prefix="component")
 
         with get_runner(component_defaults=component_defaults) as runner:

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -67,6 +67,7 @@ from torchx.specs.api import (  # noqa: F401
 )
 from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
 from torchx.specs.capabilities import CapabilityKey
+from torchx.specs.metadata_keys import app_metadata, NA, TORCHX_CONTEXT_NAME
 from torchx.util.modules import import_attr
 
 GiB: int = 1024
@@ -199,6 +200,7 @@ def get_named_resources(res: str) -> Resource:
 
 
 __all__ = [
+    "app_metadata",
     "AppDef",
     "AppDryRunInfo",
     "AppHandle",
@@ -212,6 +214,7 @@ __all__ = [
     "is_terminal",
     "macros",
     "MISSING",
+    "NA",
     "NONE",
     "NULL_RESOURCE",
     "parse_app_handle",
@@ -237,6 +240,7 @@ __all__ = [
     "materialize_appdef",
     "parse_mounts",
     "ALL",
+    "TORCHX_CONTEXT_NAME",
     "TORCHX_HOME",
     "Workspace",
 ]

--- a/torchx/specs/metadata_keys.py
+++ b/torchx/specs/metadata_keys.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Well-known TorchX metadata key and env-var spellings.
+
+These literals are a **wire contract**: schedulers stamp them into submitted
+jobs' metadata and downstream telemetry joins on the exact spellings. Import
+them from here instead of re-spelling the strings at each writer site.
+"""
+
+#: Env var identifying the calling context (e.g. ``cli_run``, a pipeline
+#: name). Stamped into job metadata as :py:attr:`app_metadata.CONTEXT`.
+TORCHX_CONTEXT_NAME: str = "TORCHX_CONTEXT_NAME"
+
+#: Sentinel written when a metadata value is not available (e.g.
+#: :py:data:`TORCHX_CONTEXT_NAME` unset at submit time).
+NA: str = "<<NA>>"
+
+
+class app_metadata:
+    """Keys stamped into a submitted job's app-level metadata by schedulers."""
+
+    CONTEXT: str = "torchx/context"
+    VERSION: str = "torchx/version"
+    SCHEDULER: str = "torchx/scheduler"
+
+    #: Prefix for per-role metadata keys: ``torchx/roles.<role_name>...``.
+    #: The schedulers that stamp these keys validate role (task-group) names
+    #: against a charset that forbids ``.`` and ``/``, so the first ``.``
+    #: after the prefix always terminates the role name, keeping these keys
+    #: unambiguous to parse.
+    ROLES_PREFIX: str = "torchx/roles."

--- a/torchx/specs/test/metadata_keys_test.py
+++ b/torchx/specs/test/metadata_keys_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from torchx.specs import app_metadata, NA, TORCHX_CONTEXT_NAME
+
+
+class MetadataKeysGoldenSpellingTest(unittest.TestCase):
+    """These literals are downstream telemetry join keys — a changed spelling
+    silently breaks downstream telemetry, so each is asserted against the
+    literal."""
+
+    def test_env_var_spelling(self) -> None:
+        self.assertEqual(
+            "TORCHX_CONTEXT_NAME",
+            TORCHX_CONTEXT_NAME,
+            "context env var is a wire contract",
+        )
+
+    def test_na_sentinel_spelling(self) -> None:
+        self.assertEqual("<<NA>>", NA, "NA sentinel is a wire contract")
+
+    def test_app_metadata_key_spellings(self) -> None:
+        self.assertEqual(
+            "torchx/context",
+            app_metadata.CONTEXT,
+            "context metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/version",
+            app_metadata.VERSION,
+            "version metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/scheduler",
+            app_metadata.SCHEDULER,
+            "scheduler metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/roles.",
+            app_metadata.ROLES_PREFIX,
+            "per-role metadata key prefix is a wire contract",
+        )


### PR DESCRIPTION
Summary:

The metadata spellings that downstream telemetry joins on (`torchx/context`, `torchx/version`, `torchx/scheduler`, the `TORCHX_CONTEXT_NAME` env var, the `<<NA>>` sentinel) were **re-spelled independently at every writer site**. This diff adds `torchx.specs.metadata_keys` as their single home:

```python
from torchx.specs import app_metadata, NA, TORCHX_CONTEXT_NAME

metadata[app_metadata.CONTEXT] = os.environ.get(TORCHX_CONTEXT_NAME, NA)
```

- Writer sites migrate to the constants: `cli/cmd_run.py` and the three fb stampers (`mast_scheduler_base.py`, `fb/hpc/mast.py`, `fb/hpc/msl.py`).
- `specs/fb/constants.py`'s overlapping enum members (`Env.CONTEXT_NAME`, `Metadata.{CONTEXT,VERSION,SCHEDULER}`) become aliases defined *from* the canonical constants, so they cannot drift.
- `app_metadata.ROLES_PREFIX` (`torchx/roles.`) reserves the per-role key namespace; role names normalize to `[a-zA-Z0-9_-]`, so the first `.` after the prefix always terminates the role name (invariant documented on the constant).
- These are Scuba join keys — golden-spelling tests assert every literal, and the existing `mast_scheduler_test` literal assertion on `torchx/context` guards the writer path end-to-end.

**TBD fork plan:** the fb-file edits are alias-only — written values stay byte-identical because the enum values are unchanged — so the fork (`genai/msl/torchx_plugins`) is unaffected today. Migrating the fork to the public `metadata_keys` API (deleting its `intern/constants.py` spellings) is the planned plugin-side follow-on, gated on the torchx-nightly pickup of this stack.

Reviewed By: athmasagar

Differential Revision: D116126081
