### PR TITLE
(bugfix)[5/7][torchx][specs] Overlay format marker stops cross-kind misfire (#1385)

### DIFF
--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -26,7 +26,7 @@ from torchx.cli.cmd_log import get_logs
 from torchx.runner import config, get_runner, Runner
 from torchx.runner.config import load_sections
 from torchx.schedulers import get_default_scheduler_name, get_scheduler_factories
-from torchx.specs import CfgVal, Workspace
+from torchx.specs import CfgVal, TORCHX_CONTEXT_NAME, Workspace
 from torchx.specs.finder import (
     _Component,
     ComponentNotFoundException,
@@ -444,7 +444,7 @@ class CmdRun(SubCommand):
             self._run_from_cli_args(runner, args)
 
     def run(self, args: argparse.Namespace) -> None:
-        os.environ["TORCHX_CONTEXT_NAME"] = os.getenv("TORCHX_CONTEXT_NAME", "cli_run")
+        os.environ[TORCHX_CONTEXT_NAME] = os.getenv(TORCHX_CONTEXT_NAME, "cli_run")
         component_defaults = load_sections(prefix="component")
 
         with get_runner(component_defaults=component_defaults) as runner:

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -67,6 +67,7 @@ from torchx.specs.api import (  # noqa: F401
 )
 from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
 from torchx.specs.capabilities import CapabilityKey
+from torchx.specs.metadata_keys import app_metadata, NA, TORCHX_CONTEXT_NAME
 from torchx.util.modules import import_attr
 
 GiB: int = 1024
@@ -199,6 +200,7 @@ def get_named_resources(res: str) -> Resource:
 
 
 __all__ = [
+    "app_metadata",
     "AppDef",
     "AppDryRunInfo",
     "AppHandle",
@@ -212,6 +214,7 @@ __all__ = [
     "is_terminal",
     "macros",
     "MISSING",
+    "NA",
     "NONE",
     "NULL_RESOURCE",
     "parse_app_handle",
@@ -237,6 +240,7 @@ __all__ = [
     "materialize_appdef",
     "parse_mounts",
     "ALL",
+    "TORCHX_CONTEXT_NAME",
     "TORCHX_HOME",
     "Workspace",
 ]

--- a/torchx/specs/metadata_keys.py
+++ b/torchx/specs/metadata_keys.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Well-known TorchX metadata key and env-var spellings.
+
+These literals are a **wire contract**: schedulers stamp them into submitted
+jobs' metadata and downstream telemetry joins on the exact spellings. Import
+them from here instead of re-spelling the strings at each writer site.
+"""
+
+#: Env var identifying the calling context (e.g. ``cli_run``, a pipeline
+#: name). Stamped into job metadata as :py:attr:`app_metadata.CONTEXT`.
+TORCHX_CONTEXT_NAME: str = "TORCHX_CONTEXT_NAME"
+
+#: Sentinel written when a metadata value is not available (e.g.
+#: :py:data:`TORCHX_CONTEXT_NAME` unset at submit time).
+NA: str = "<<NA>>"
+
+
+class app_metadata:
+    """Keys stamped into a submitted job's app-level metadata by schedulers."""
+
+    CONTEXT: str = "torchx/context"
+    VERSION: str = "torchx/version"
+    SCHEDULER: str = "torchx/scheduler"
+
+    #: Prefix for per-role metadata keys: ``torchx/roles.<role_name>...``.
+    #: The schedulers that stamp these keys validate role (task-group) names
+    #: against a charset that forbids ``.`` and ``/``, so the first ``.``
+    #: after the prefix always terminates the role name, keeping these keys
+    #: unambiguous to parse.
+    ROLES_PREFIX: str = "torchx/roles."

--- a/torchx/specs/overlays.py
+++ b/torchx/specs/overlays.py
@@ -123,6 +123,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from dataclasses import dataclass
 from typing import Any, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -131,6 +132,12 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 _Overlay = dict[str, Any]
+
+# Format marker stamped into ``metadata[namespace]`` by :py:func:`set_overlay`.
+# Its presence means the namespace dict is in the nested ``{kind: overlay}``
+# format, so :py:func:`get_overlay` never falls back to treating the whole
+# namespace dict as a flat overlay for a kind that is not present.
+_FORMAT_KEY = "__torchx_overlays__"
 
 # Operator key prefixes. Each function returns a string key for use in overlay
 # dicts. The prefix encodes the operation; the suffix encodes the field name
@@ -501,7 +508,15 @@ def set_overlay(
         namespace: Scheduler namespace (e.g., ``"kubernetes"``, ``"mast"``).
         kind: Scheduler struct type (e.g., ``"V1Pod"``,
             ``"HpcJobDefinition"``).
+
+    Raises:
+        ValueError: if ``kind`` is the reserved nested-format marker key.
     """
+    if kind == _FORMAT_KEY:
+        raise ValueError(
+            f"overlay kind `{kind}` is reserved for the nested-format marker"
+        )
+
     # Cast metadata to allow nested dicts
     # Note: AppDef.metadata is typed as dict[str, str] but overlays require nested dicts
     metadata = cast(_Metadata, target.metadata)
@@ -522,6 +537,10 @@ def set_overlay(
         ns_dict = {}
         metadata[namespace] = ns_dict
 
+    # Stamp the nested-format marker so get_overlay never misreads this
+    # namespace dict as a flat single-kind overlay.
+    ns_dict[_FORMAT_KEY] = True
+
     # Ensure kind dict exists and merge
     if kind not in ns_dict:
         ns_dict[kind] = {}
@@ -538,16 +557,31 @@ def get_overlay(
     target: AppDef | Role,
     namespace: str,
     kind: str,
+    *,
+    flat_fallback: bool = True,
 ) -> _Overlay:
     """Retrieve overlay from ``target.metadata[namespace][kind]``.
 
     Returns ``{}`` if not found. If ``metadata[namespace]`` is a string,
     it is loaded as a file URI via ``fsspec`` (JSON or YAML).
 
-    For backwards compatibility, if ``kind`` is not a key in
-    ``metadata[namespace]``, the entire namespace dict is returned as a
-    flat overlay (with a deprecation warning).
+    Namespace dicts written by :py:func:`set_overlay` carry a format marker
+    and are **nested-only**: a missing ``kind`` returns ``{}`` — an overlay
+    stored under kind ``A`` is never handed to a reader asking for kind ``B``.
+
+    For backwards compatibility, an *unmarked* namespace dict (written via
+    direct metadata access) whose ``kind`` key is missing is returned whole
+    as a flat overlay (with a deprecation warning), unless *flat_fallback*
+    is ``False``.
+
+    Raises:
+        ValueError: if ``kind`` is the reserved nested-format marker key.
     """
+    if kind == _FORMAT_KEY:
+        raise ValueError(
+            f"overlay kind `{kind}` is reserved for the nested-format marker"
+        )
+
     if namespace not in target.metadata:
         return {}
 
@@ -566,6 +600,25 @@ def get_overlay(
         if isinstance(overlay, dict):
             return overlay
 
+    available_kinds = [k for k in ns_value if k != _FORMAT_KEY]
+
+    # Marked nested format: a missing kind is an empty overlay, never the
+    # flat fallback. Debug-level: schedulers legitimately probe for kinds
+    # the writer never set (e.g. both TaskGroup kinds on every role).
+    if ns_value.get(_FORMAT_KEY):
+        if available_kinds:
+            logger.debug(
+                "overlay kind `%s` not found in namespace `%s` "
+                "(available kinds: %s)",
+                kind,
+                namespace,
+                available_kinds,
+            )
+        return {}
+
+    if not flat_fallback:
+        return {}
+
     # Backwards compat: flat format metadata[namespace] = {overlay} (no kind key).
     # Only fall back if ns_value doesn't look like nested format (multiple
     # dict-valued keys = nested, e.g. {"HpcTaskGroupSpec": {...}, ...}).
@@ -581,7 +634,7 @@ def get_overlay(
             "for the nested format",
             kind,
             namespace,
-            list(ns_value.keys()),
+            available_kinds,
             namespace,
             namespace,
             kind,
@@ -651,3 +704,65 @@ def validate_overlay(
             if suggestion:
                 msg = f"{msg} {suggestion}"
             raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class OverlaySpec:
+    """Declares a scheduler's overlay surface once — namespace, kind, and the
+    keys users must set via ``Role``/``AppDef`` attributes instead.
+
+    Scheduler authors define one per overlay kind and use it at both ends,
+    instead of re-spelling ``(namespace, kind, blocklist)`` at every
+    :py:func:`set_overlay`/:py:func:`get_overlay` call site:
+
+    .. doctest::
+
+        >>> from torchx.specs import Role
+        >>> from torchx.specs.overlays import OverlaySpec
+
+        >>> V1POD = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+
+        >>> role = Role(name="trainer", image="img", entrypoint="train.py")
+        >>> V1POD.set(role, {"spec": {"nodeSelector": {"gpu": "true"}}})
+        >>> V1POD.get(role)
+        {'spec': {'nodeSelector': {'gpu': 'true'}}}
+
+    Args:
+        namespace: scheduler namespace (e.g. ``"kubernetes"``, ``"mast"``).
+        kind: scheduler struct type (e.g. ``"V1Pod"``, ``"HpcJobDefinition"``).
+        blocklist: keys that must be set via ``Role``/``AppDef`` attributes;
+            :py:meth:`get` raises ``ValueError`` when the stored overlay
+            contains any of them.
+    """
+
+    namespace: str
+    kind: str
+    blocklist: tuple[str, ...] = ()
+
+    def set(self, target: AppDef | Role, overlay: _Overlay) -> None:
+        """Store *overlay* via :py:func:`set_overlay` (accumulates).
+
+        Validates against ``blocklist`` so a disallowed key fails at write
+        time (at the call site that supplied it), not at read time.
+        """
+        validate_overlay(
+            overlay,
+            blocklist=list(self.blocklist),
+            overlay_name=self.kind,
+        )
+        set_overlay(target, self.namespace, self.kind, overlay)
+
+    def get(self, target: AppDef | Role) -> _Overlay:
+        """Retrieve the stored overlay, validated against ``blocklist``.
+
+        Reads nested-format only (``flat_fallback=False``) — an
+        :py:class:`OverlaySpec` reader never inherits a legacy flat
+        namespace dict written for some other kind.
+        """
+        overlay = get_overlay(target, self.namespace, self.kind, flat_fallback=False)
+        validate_overlay(
+            overlay,
+            blocklist=list(self.blocklist),
+            overlay_name=self.kind,
+        )
+        return overlay

--- a/torchx/specs/test/metadata_keys_test.py
+++ b/torchx/specs/test/metadata_keys_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from torchx.specs import app_metadata, NA, TORCHX_CONTEXT_NAME
+
+
+class MetadataKeysGoldenSpellingTest(unittest.TestCase):
+    """These literals are downstream telemetry join keys — a changed spelling
+    silently breaks downstream telemetry, so each is asserted against the
+    literal."""
+
+    def test_env_var_spelling(self) -> None:
+        self.assertEqual(
+            "TORCHX_CONTEXT_NAME",
+            TORCHX_CONTEXT_NAME,
+            "context env var is a wire contract",
+        )
+
+    def test_na_sentinel_spelling(self) -> None:
+        self.assertEqual("<<NA>>", NA, "NA sentinel is a wire contract")
+
+    def test_app_metadata_key_spellings(self) -> None:
+        self.assertEqual(
+            "torchx/context",
+            app_metadata.CONTEXT,
+            "context metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/version",
+            app_metadata.VERSION,
+            "version metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/scheduler",
+            app_metadata.SCHEDULER,
+            "scheduler metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/roles.",
+            app_metadata.ROLES_PREFIX,
+            "per-role metadata key prefix is a wire contract",
+        )

--- a/torchx/specs/test/overlays_test.py
+++ b/torchx/specs/test/overlays_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 import copy
 import json
+import logging
 import os
 import tempfile
 import unittest
@@ -14,11 +15,13 @@ from typing import Any
 
 from torchx.specs import AppDef, Role
 from torchx.specs.overlays import (
+    _FORMAT_KEY,
     _load_overlay_file,
     apply_overlay,
     DEL,
     get_overlay,
     JOIN,
+    OverlaySpec,
     PUT,
     set_overlay,
     validate_overlay,
@@ -382,6 +385,164 @@ class SetGetOverlayTest(unittest.TestCase):
         role = Role(name="w", image="img", entrypoint="e")
         role.metadata["kubernetes"] = 123
         self.assertEqual(get_overlay(role, "kubernetes", "V1Pod"), {})
+
+    def test_set_kind_a_read_kind_b_returns_empty(self) -> None:
+        """Misfire regression: a single kind written via set_overlay must not
+        be handed to a reader asking for a different kind."""
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "mast", "HpcTaskGroupSpec", {"resourceRequirement": {}})
+
+        self.assertEqual(
+            {},
+            get_overlay(role, "mast", "HpcTaskGroupDefinition"),
+            "kind written as HpcTaskGroupSpec must not fall back flat for "
+            "HpcTaskGroupDefinition readers",
+        )
+        # ... while the written kind stays readable
+        self.assertEqual(
+            {"resourceRequirement": {}},
+            get_overlay(role, "mast", "HpcTaskGroupSpec"),
+        )
+
+    def test_marker_survives_set_overlay_merges(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "sched", "JobSpec", {"priority": "high"})
+        set_overlay(role, "sched", "JobSpec", {"oncall": "myoncall"})
+        set_overlay(role, "sched", "JobConfig", {"retries": 3})
+
+        self.assertTrue(
+            role.metadata["sched"][_FORMAT_KEY],
+            "format marker must survive accumulating set_overlay calls",
+        )
+
+    def test_marker_survives_metadata_dict_merge(self) -> None:
+        """apply_overlay-merging two marked namespace dicts keeps the marker."""
+        role_a = Role(name="a", image="img", entrypoint="e")
+        role_b = Role(name="b", image="img", entrypoint="e")
+        set_overlay(role_a, "sched", "JobSpec", {"priority": "high"})
+        set_overlay(role_b, "sched", "JobConfig", {"retries": 3})
+
+        merged = copy.deepcopy(role_a.metadata)
+        apply_overlay(merged, role_b.metadata)
+
+        self.assertTrue(
+            merged["sched"][_FORMAT_KEY],
+            "format marker must survive merging namespace dicts",
+        )
+        role_a.metadata = merged
+        self.assertEqual(
+            {},
+            get_overlay(role_a, "sched", "SomethingElse"),
+            "merged namespace dict must stay nested-only",
+        )
+
+    def test_marked_kind_miss_logs_debug_not_warning(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "sched", "JobSpec", {"priority": "high"})
+
+        with self.assertLogs("torchx.specs.overlays", level="DEBUG") as logs:
+            self.assertEqual({}, get_overlay(role, "sched", "JobConfig"))
+        self.assertTrue(
+            all(r.levelno < logging.WARNING for r in logs.records),
+            "kind miss on a marked namespace is a normal scheduler probe,"
+            " must not warn",
+        )
+        self.assertNotIn(
+            _FORMAT_KEY,
+            "\n".join(logs.output),
+            "format marker must not be listed as an available kind",
+        )
+        self.assertIn("JobSpec", "\n".join(logs.output))
+
+    def test_legacy_unmarked_flat_still_falls_back_with_warning(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        # written via direct metadata access — no marker
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        with self.assertLogs("torchx.specs.overlays", level="WARNING") as logs:
+            overlay = get_overlay(role, "kubernetes", "V1Pod")
+
+        self.assertEqual(
+            {"spec": {"nodeSelector": {"gpu": "true"}}},
+            overlay,
+            "unmarked flat namespace dict must keep the legacy fallback",
+        )
+        self.assertIn("flat", "\n".join(logs.output))
+
+    def test_flat_fallback_false_disables_legacy_fallback(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        self.assertEqual(
+            {},
+            get_overlay(role, "kubernetes", "V1Pod", flat_fallback=False),
+            "flat_fallback=False must never return the flat namespace dict",
+        )
+
+
+class OverlaySpecTest(unittest.TestCase):
+    def test_set_get_round_trip(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+
+        spec.set(role, {"spec": {"nodeSelector": {"gpu": "true"}}})
+        spec.set(role, {"spec": {"tolerations": [{"key": "gpu"}]}})
+
+        self.assertEqual(
+            {
+                "spec": {
+                    "nodeSelector": {"gpu": "true"},
+                    "tolerations": [{"key": "gpu"}],
+                }
+            },
+            spec.get(role),
+            "OverlaySpec.set calls must accumulate like set_overlay",
+        )
+
+    def test_get_missing_returns_empty(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+        self.assertEqual({}, spec.get(role))
+
+    def test_get_never_inherits_flat_namespace(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        self.assertEqual(
+            {},
+            spec.get(role),
+            "OverlaySpec.get must read nested-format only",
+        )
+
+    def test_blocklist_enforced_on_set(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+        role = Role(name="w", image="img", entrypoint="e")
+
+        with self.assertRaisesRegex(ValueError, "V1Pod.env"):
+            spec.set(role, {"env": {"FOO": "bar"}})
+        self.assertEqual(
+            {},
+            spec.get(role),
+            "a rejected OverlaySpec.set must not store anything",
+        )
+
+    def test_blocklist_enforced_on_get(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+        role = Role(name="w", image="img", entrypoint="e")
+        # write through the raw storage API (bypasses OverlaySpec.set validation)
+        set_overlay(role, "kubernetes", "V1Pod", {"env": {"FOO": "bar"}})
+
+        with self.assertRaisesRegex(ValueError, "V1Pod.env"):
+            spec.get(role)
+
+    def test_reserved_format_marker_kind_rejected(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            set_overlay(role, "kubernetes", _FORMAT_KEY, {"spec": {}})
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            get_overlay(role, "kubernetes", _FORMAT_KEY)
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

`get_overlay`'s legacy flat fallback fires whenever the requested kind is missing and the namespace dict "doesn't look nested" (single kind = single key), which **hands one kind's overlay to a reader asking for a different kind**:

**Before** (kind written = `HpcTaskGroupSpec`, kind read = `HpcTaskGroupDefinition`):
```python
set_overlay(role, "mast", "HpcTaskGroupSpec", {"resourceRequirement": {}})
get_overlay(role, "mast", "HpcTaskGroupDefinition")
# -> {'HpcTaskGroupSpec': {'resourceRequirement': {}}}   # misfire
```

**After**:
```python
get_overlay(role, "mast", "HpcTaskGroupDefinition")
# -> {}   (debug log: kind not found, available kinds: ['HpcTaskGroupSpec'])
```

**This diff fixes this by** stamping a format marker (`__torchx_overlays__: True`) into the namespace dict on every `set_overlay`: marker present means nested-only — a missing kind is `{}`, never the flat fallback, and the marker is excluded from available-kinds logs. The marked kind miss logs at debug: schedulers probe kinds the writer never set (both TaskGroup kinds per role), so a warning would fire on every normal MAST submit. Unmarked dicts (direct metadata writes) keep the legacy heuristic + deprecation warning. A `flat_fallback: bool = True` kwarg lets readers opt out of the legacy path entirely.

**Rider**: `OverlaySpec` (frozen dataclass: namespace, kind, blocklist) — declares a scheduler's overlay surface once instead of re-spelling `(namespace, kind, blocklist)` at every call site; its `.get` reads `flat_fallback=False` and validates against the blocklist.

NOTE: follow-on — `components/fb/dist.py:323` and `components/fb/mtia.py:72,397` still write `metadata["mast"]` directly (mtia wholesale-replaces the dict); migrate to `set_overlay`.

Reviewed By: athmasagar

Differential Revision: D116126079
