### PR TITLE
(perf)[6/7][torchx][specs] Make named-resource discovery lazy on first lookup (#1387)

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -215,10 +215,23 @@ Once installed, use the named resource:
 
 .. testsetup:: role
 
-   from torchx.specs import _named_resource_factories, Resource
+   import os
+   import sys
+   import types
 
-   _named_resource_factories["gpu_x2"] = lambda: Resource(cpu=16, gpu=2, memMB=122_000)
+   from torchx.specs import named_resources, Resource
 
+   _mod = types.ModuleType("_gpu_x2_resources")
+   _mod.NAMED_RESOURCES = {"gpu_x2": lambda: Resource(cpu=16, gpu=2, memMB=122_000)}
+   sys.modules["_gpu_x2_resources"] = _mod
+   os.environ["TORCHX_CUSTOM_NAMED_RESOURCES"] = "_gpu_x2_resources"
+   named_resources.reset()
+
+.. testcleanup:: role
+
+   del os.environ["TORCHX_CUSTOM_NAMED_RESOURCES"]
+   del sys.modules["_gpu_x2_resources"]
+   named_resources.reset()
 
 .. doctest:: role
 

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -26,7 +26,7 @@ from torchx.cli.cmd_log import get_logs
 from torchx.runner import config, get_runner, Runner
 from torchx.runner.config import load_sections
 from torchx.schedulers import get_default_scheduler_name, get_scheduler_factories
-from torchx.specs import CfgVal, Workspace
+from torchx.specs import CfgVal, TORCHX_CONTEXT_NAME, Workspace
 from torchx.specs.finder import (
     _Component,
     ComponentNotFoundException,
@@ -444,7 +444,7 @@ class CmdRun(SubCommand):
             self._run_from_cli_args(runner, args)
 
     def run(self, args: argparse.Namespace) -> None:
-        os.environ["TORCHX_CONTEXT_NAME"] = os.getenv("TORCHX_CONTEXT_NAME", "cli_run")
+        os.environ[TORCHX_CONTEXT_NAME] = os.getenv(TORCHX_CONTEXT_NAME, "cli_run")
         component_defaults = load_sections(prefix="component")
 
         with get_runner(component_defaults=component_defaults) as runner:

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -27,7 +27,8 @@ via a :py:class:`~torchx.schedulers.api.Scheduler`.
 
 import difflib
 import os
-from typing import Callable, Iterator, Mapping
+import threading
+from typing import Callable, Iterator, KeysView, Mapping
 
 from torchx import plugins
 from torchx.specs.api import (  # noqa: F401
@@ -75,57 +76,100 @@ GiB: int = 1024
 
 ResourceFactory = Callable[[], Resource]
 
-AWS_NAMED_RESOURCES: Mapping[str, ResourceFactory] = import_attr(
-    "torchx.specs.named_resources_aws", "NAMED_RESOURCES", default={}
-)
-GENERIC_NAMED_RESOURCES: Mapping[str, ResourceFactory] = import_attr(
-    "torchx.specs.named_resources_generic", "NAMED_RESOURCES", default={}
-)
-CUSTOM_NAMED_RESOURCES: Mapping[str, ResourceFactory] = import_attr(
-    os.environ.get("TORCHX_CUSTOM_NAMED_RESOURCES", "torchx.specs.fb.named_resources"),
-    "NAMED_RESOURCES",
-    default={},
-)
-
-
-def _load_named_resources() -> dict[str, Callable[[], Resource]]:
-    materialized_resources: dict[str, Callable[[], Resource]] = {}
-
-    for name, resource in {
-        **GENERIC_NAMED_RESOURCES,
-        **AWS_NAMED_RESOURCES,
-        **CUSTOM_NAMED_RESOURCES,
-        **plugins.registry().get(plugins.PluginType.NAMED_RESOURCE),
-    }.items():
-        materialized_resources[name] = resource
-
-    materialized_resources["NULL"] = lambda: NULL_RESOURCE
-    materialized_resources["MISSING"] = lambda: NULL_RESOURCE
-    return materialized_resources
-
-
-_named_resource_factories: dict[str, Callable[[], Resource]] = _load_named_resources()
-
 
 class _NamedResourcesLibrary:
+    """Lazily-loaded named-resource lookup.
+
+    ``import torchx.specs`` performs no resource-module import or plugin
+    discovery — the AWS/generic/custom resource modules and the plugin
+    registry are loaded on first lookup and cached.
+
+    Discovery is single-flight: concurrent first lookups block until one
+    scan populates the cache, and a re-entrant lookup (a plugin module
+    looking up a named resource at import time, mid-scan) raises
+    ``RuntimeError``, which the plugin scanner records as a load error for
+    that module.
+    """
+
+    def __init__(self) -> None:
+        self._factories: dict[str, ResourceFactory] | None = None
+        self._lock = threading.RLock()
+        self._loading = False
+
+    def _load(self) -> dict[str, ResourceFactory]:
+        factories = self._factories
+        if factories is not None:
+            return factories
+        # double-checked: the lock serializes concurrent first lookups so
+        # discovery runs exactly once; the RLock lets a re-entrant lookup on
+        # the loading thread reach the sentinel check below instead of
+        # deadlocking
+        with self._lock:
+            if self._factories is not None:
+                return self._factories
+            if self._loading:
+                raise RuntimeError(
+                    "re-entrant named-resource lookup: discovery is already in"
+                    " progress on this thread. A plugin module is likely looking"
+                    " up a named resource at import time; the registered set is"
+                    " incomplete mid-scan, so defer the lookup into the factory"
+                    " body."
+                )
+            self._loading = True
+            try:
+                aws: Mapping[str, ResourceFactory] = import_attr(
+                    "torchx.specs.named_resources_aws", "NAMED_RESOURCES", default={}
+                )
+                generic: Mapping[str, ResourceFactory] = import_attr(
+                    "torchx.specs.named_resources_generic",
+                    "NAMED_RESOURCES",
+                    default={},
+                )
+                custom: Mapping[str, ResourceFactory] = import_attr(
+                    os.environ.get(
+                        "TORCHX_CUSTOM_NAMED_RESOURCES",
+                        "torchx.specs.fb.named_resources",
+                    ),
+                    "NAMED_RESOURCES",
+                    default={},
+                )
+                factories = {
+                    **generic,
+                    **aws,
+                    **custom,
+                    **plugins.registry().get(plugins.PluginType.NAMED_RESOURCE),
+                }
+                factories["NULL"] = lambda: NULL_RESOURCE
+                factories["MISSING"] = lambda: NULL_RESOURCE
+                self._factories = factories
+            finally:
+                self._loading = False
+            return factories
+
+    def reset(self) -> None:
+        """Test hook: drop the cached factories so the next access re-discovers."""
+        with self._lock:
+            self._factories = None
+
     def __getitem__(self, key: str) -> Resource:
-        if key in _named_resource_factories:
-            return _named_resource_factories[key]()
+        factories = self._load()
+        if key in factories:
+            return factories[key]()
         else:
             matches = difflib.get_close_matches(
                 key,
-                _named_resource_factories.keys(),
+                factories.keys(),
                 n=1,
             )
             if matches:
                 msg = f"Did you mean `{matches[0]}`?"
             else:
-                msg = f"Registered named resources: {list(_named_resource_factories.keys())}"
+                msg = f"Registered named resources: {list(factories.keys())}"
 
             raise KeyError(f"No named resource found for `{key}`. {msg}")
 
     def __contains__(self, key: str) -> bool:
-        return key in _named_resource_factories
+        return key in self._load()
 
     def __iter__(self) -> Iterator[str]:
         """Iterates through the names of the registered named_resources.
@@ -141,8 +185,27 @@ class _NamedResourcesLibrary:
                 assert isinstance(resource, specs.Resource)
 
         """
-        for key in _named_resource_factories:
-            yield (key)
+        yield from self._load()
+
+    def keys(self) -> KeysView[str]:
+        """The names of the registered named resources."""
+        return self._load().keys()
+
+    def items(self) -> Iterator[tuple[str, Resource]]:
+        """Iterates ``(name, resource)`` pairs, materializing each resource.
+
+        Usage:
+
+        .. doctest::
+
+            from torchx import specs
+
+            for name, resource in specs.named_resources.items():
+                assert isinstance(resource, specs.Resource)
+
+        """
+        for name, factory in self._load().items():
+            yield name, factory()
 
 
 named_resources: _NamedResourcesLibrary = _NamedResourcesLibrary()

--- a/torchx/specs/__init__.py
+++ b/torchx/specs/__init__.py
@@ -67,6 +67,7 @@ from torchx.specs.api import (  # noqa: F401
 )
 from torchx.specs.builders import make_app_handle, materialize_appdef, parse_mounts
 from torchx.specs.capabilities import CapabilityKey
+from torchx.specs.metadata_keys import app_metadata, NA, TORCHX_CONTEXT_NAME
 from torchx.util.modules import import_attr
 
 GiB: int = 1024
@@ -199,6 +200,7 @@ def get_named_resources(res: str) -> Resource:
 
 
 __all__ = [
+    "app_metadata",
     "AppDef",
     "AppDryRunInfo",
     "AppHandle",
@@ -212,6 +214,7 @@ __all__ = [
     "is_terminal",
     "macros",
     "MISSING",
+    "NA",
     "NONE",
     "NULL_RESOURCE",
     "parse_app_handle",
@@ -237,6 +240,7 @@ __all__ = [
     "materialize_appdef",
     "parse_mounts",
     "ALL",
+    "TORCHX_CONTEXT_NAME",
     "TORCHX_HOME",
     "Workspace",
 ]

--- a/torchx/specs/metadata_keys.py
+++ b/torchx/specs/metadata_keys.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Well-known TorchX metadata key and env-var spellings.
+
+These literals are a **wire contract**: schedulers stamp them into submitted
+jobs' metadata and downstream telemetry joins on the exact spellings. Import
+them from here instead of re-spelling the strings at each writer site.
+"""
+
+#: Env var identifying the calling context (e.g. ``cli_run``, a pipeline
+#: name). Stamped into job metadata as :py:attr:`app_metadata.CONTEXT`.
+TORCHX_CONTEXT_NAME: str = "TORCHX_CONTEXT_NAME"
+
+#: Sentinel written when a metadata value is not available (e.g.
+#: :py:data:`TORCHX_CONTEXT_NAME` unset at submit time).
+NA: str = "<<NA>>"
+
+
+class app_metadata:
+    """Keys stamped into a submitted job's app-level metadata by schedulers."""
+
+    CONTEXT: str = "torchx/context"
+    VERSION: str = "torchx/version"
+    SCHEDULER: str = "torchx/scheduler"
+
+    #: Prefix for per-role metadata keys: ``torchx/roles.<role_name>...``.
+    #: The schedulers that stamp these keys validate role (task-group) names
+    #: against a charset that forbids ``.`` and ``/``, so the first ``.``
+    #: after the prefix always terminates the role name, keeping these keys
+    #: unambiguous to parse.
+    ROLES_PREFIX: str = "torchx/roles."

--- a/torchx/specs/overlays.py
+++ b/torchx/specs/overlays.py
@@ -123,6 +123,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from dataclasses import dataclass
 from typing import Any, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -131,6 +132,12 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 _Overlay = dict[str, Any]
+
+# Format marker stamped into ``metadata[namespace]`` by :py:func:`set_overlay`.
+# Its presence means the namespace dict is in the nested ``{kind: overlay}``
+# format, so :py:func:`get_overlay` never falls back to treating the whole
+# namespace dict as a flat overlay for a kind that is not present.
+_FORMAT_KEY = "__torchx_overlays__"
 
 # Operator key prefixes. Each function returns a string key for use in overlay
 # dicts. The prefix encodes the operation; the suffix encodes the field name
@@ -501,7 +508,15 @@ def set_overlay(
         namespace: Scheduler namespace (e.g., ``"kubernetes"``, ``"mast"``).
         kind: Scheduler struct type (e.g., ``"V1Pod"``,
             ``"HpcJobDefinition"``).
+
+    Raises:
+        ValueError: if ``kind`` is the reserved nested-format marker key.
     """
+    if kind == _FORMAT_KEY:
+        raise ValueError(
+            f"overlay kind `{kind}` is reserved for the nested-format marker"
+        )
+
     # Cast metadata to allow nested dicts
     # Note: AppDef.metadata is typed as dict[str, str] but overlays require nested dicts
     metadata = cast(_Metadata, target.metadata)
@@ -522,6 +537,10 @@ def set_overlay(
         ns_dict = {}
         metadata[namespace] = ns_dict
 
+    # Stamp the nested-format marker so get_overlay never misreads this
+    # namespace dict as a flat single-kind overlay.
+    ns_dict[_FORMAT_KEY] = True
+
     # Ensure kind dict exists and merge
     if kind not in ns_dict:
         ns_dict[kind] = {}
@@ -538,16 +557,31 @@ def get_overlay(
     target: AppDef | Role,
     namespace: str,
     kind: str,
+    *,
+    flat_fallback: bool = True,
 ) -> _Overlay:
     """Retrieve overlay from ``target.metadata[namespace][kind]``.
 
     Returns ``{}`` if not found. If ``metadata[namespace]`` is a string,
     it is loaded as a file URI via ``fsspec`` (JSON or YAML).
 
-    For backwards compatibility, if ``kind`` is not a key in
-    ``metadata[namespace]``, the entire namespace dict is returned as a
-    flat overlay (with a deprecation warning).
+    Namespace dicts written by :py:func:`set_overlay` carry a format marker
+    and are **nested-only**: a missing ``kind`` returns ``{}`` — an overlay
+    stored under kind ``A`` is never handed to a reader asking for kind ``B``.
+
+    For backwards compatibility, an *unmarked* namespace dict (written via
+    direct metadata access) whose ``kind`` key is missing is returned whole
+    as a flat overlay (with a deprecation warning), unless *flat_fallback*
+    is ``False``.
+
+    Raises:
+        ValueError: if ``kind`` is the reserved nested-format marker key.
     """
+    if kind == _FORMAT_KEY:
+        raise ValueError(
+            f"overlay kind `{kind}` is reserved for the nested-format marker"
+        )
+
     if namespace not in target.metadata:
         return {}
 
@@ -566,6 +600,25 @@ def get_overlay(
         if isinstance(overlay, dict):
             return overlay
 
+    available_kinds = [k for k in ns_value if k != _FORMAT_KEY]
+
+    # Marked nested format: a missing kind is an empty overlay, never the
+    # flat fallback. Debug-level: schedulers legitimately probe for kinds
+    # the writer never set (e.g. both TaskGroup kinds on every role).
+    if ns_value.get(_FORMAT_KEY):
+        if available_kinds:
+            logger.debug(
+                "overlay kind `%s` not found in namespace `%s` "
+                "(available kinds: %s)",
+                kind,
+                namespace,
+                available_kinds,
+            )
+        return {}
+
+    if not flat_fallback:
+        return {}
+
     # Backwards compat: flat format metadata[namespace] = {overlay} (no kind key).
     # Only fall back if ns_value doesn't look like nested format (multiple
     # dict-valued keys = nested, e.g. {"HpcTaskGroupSpec": {...}, ...}).
@@ -581,7 +634,7 @@ def get_overlay(
             "for the nested format",
             kind,
             namespace,
-            list(ns_value.keys()),
+            available_kinds,
             namespace,
             namespace,
             kind,
@@ -651,3 +704,65 @@ def validate_overlay(
             if suggestion:
                 msg = f"{msg} {suggestion}"
             raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class OverlaySpec:
+    """Declares a scheduler's overlay surface once — namespace, kind, and the
+    keys users must set via ``Role``/``AppDef`` attributes instead.
+
+    Scheduler authors define one per overlay kind and use it at both ends,
+    instead of re-spelling ``(namespace, kind, blocklist)`` at every
+    :py:func:`set_overlay`/:py:func:`get_overlay` call site:
+
+    .. doctest::
+
+        >>> from torchx.specs import Role
+        >>> from torchx.specs.overlays import OverlaySpec
+
+        >>> V1POD = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+
+        >>> role = Role(name="trainer", image="img", entrypoint="train.py")
+        >>> V1POD.set(role, {"spec": {"nodeSelector": {"gpu": "true"}}})
+        >>> V1POD.get(role)
+        {'spec': {'nodeSelector': {'gpu': 'true'}}}
+
+    Args:
+        namespace: scheduler namespace (e.g. ``"kubernetes"``, ``"mast"``).
+        kind: scheduler struct type (e.g. ``"V1Pod"``, ``"HpcJobDefinition"``).
+        blocklist: keys that must be set via ``Role``/``AppDef`` attributes;
+            :py:meth:`get` raises ``ValueError`` when the stored overlay
+            contains any of them.
+    """
+
+    namespace: str
+    kind: str
+    blocklist: tuple[str, ...] = ()
+
+    def set(self, target: AppDef | Role, overlay: _Overlay) -> None:
+        """Store *overlay* via :py:func:`set_overlay` (accumulates).
+
+        Validates against ``blocklist`` so a disallowed key fails at write
+        time (at the call site that supplied it), not at read time.
+        """
+        validate_overlay(
+            overlay,
+            blocklist=list(self.blocklist),
+            overlay_name=self.kind,
+        )
+        set_overlay(target, self.namespace, self.kind, overlay)
+
+    def get(self, target: AppDef | Role) -> _Overlay:
+        """Retrieve the stored overlay, validated against ``blocklist``.
+
+        Reads nested-format only (``flat_fallback=False``) — an
+        :py:class:`OverlaySpec` reader never inherits a legacy flat
+        namespace dict written for some other kind.
+        """
+        overlay = get_overlay(target, self.namespace, self.kind, flat_fallback=False)
+        validate_overlay(
+            overlay,
+            blocklist=list(self.blocklist),
+            overlay_name=self.kind,
+        )
+        return overlay

--- a/torchx/specs/test/lazy_fixture/torchx_plugins/named_resources/reentrant.py
+++ b/torchx/specs/test/lazy_fixture/torchx_plugins/named_resources/reentrant.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Re-entrancy fixture: a namespace plugin that imports ``torchx.specs`` at
+module top-level. Discovery is triggered from inside ``torchx.specs`` (first
+named-resource lookup), so this import re-enters the already-initialized
+module — it must resolve cleanly, not crash or deadlock the scan."""
+
+import torchx.specs  # noqa: F401  (the top-level re-entrant import IS the fixture)
+from torchx.plugins import register
+from torchx.specs.api import Resource
+
+
+@register.named_resource()
+def reentrant_gpu() -> Resource:
+    return Resource(cpu=1, gpu=1, memMB=1024)

--- a/torchx/specs/test/metadata_keys_test.py
+++ b/torchx/specs/test/metadata_keys_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from torchx.specs import app_metadata, NA, TORCHX_CONTEXT_NAME
+
+
+class MetadataKeysGoldenSpellingTest(unittest.TestCase):
+    """These literals are downstream telemetry join keys — a changed spelling
+    silently breaks downstream telemetry, so each is asserted against the
+    literal."""
+
+    def test_env_var_spelling(self) -> None:
+        self.assertEqual(
+            "TORCHX_CONTEXT_NAME",
+            TORCHX_CONTEXT_NAME,
+            "context env var is a wire contract",
+        )
+
+    def test_na_sentinel_spelling(self) -> None:
+        self.assertEqual("<<NA>>", NA, "NA sentinel is a wire contract")
+
+    def test_app_metadata_key_spellings(self) -> None:
+        self.assertEqual(
+            "torchx/context",
+            app_metadata.CONTEXT,
+            "context metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/version",
+            app_metadata.VERSION,
+            "version metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/scheduler",
+            app_metadata.SCHEDULER,
+            "scheduler metadata key is a downstream telemetry join key",
+        )
+        self.assertEqual(
+            "torchx/roles.",
+            app_metadata.ROLES_PREFIX,
+            "per-role metadata key prefix is a wire contract",
+        )

--- a/torchx/specs/test/named_resources_test.py
+++ b/torchx/specs/test/named_resources_test.py
@@ -8,14 +8,31 @@
 # pyre-strict
 
 
+import os
+import subprocess
+import sys
+import threading
+import time
 import unittest
+from pathlib import Path
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
+from torchx import plugins
 from torchx.specs import (
     _NamedResourcesLibrary,
     named_resources,
     NULL_RESOURCE,
     Resource,
+)
+
+# A namespace plugin package whose module imports torchx.specs at top-level.
+_LAZY_FIXTURE_DIR: str = str(Path(__file__).resolve().parent / "lazy_fixture")
+
+# A namespace plugin package whose module LOOKS UP a named resource at
+# top-level, re-entering discovery mid-scan.
+_REENTRANT_LOOKUP_FIXTURE_DIR: str = str(
+    Path(__file__).resolve().parent / "reentrant_lookup_fixture"
 )
 
 
@@ -24,42 +41,186 @@ def mock_resource() -> Resource:
 
 
 class NamedResourcesTest(unittest.TestCase):
-    @patch("torchx.specs._named_resource_factories")
-    def test_named_resources_library(self, mock_named_resources: MagicMock) -> None:
-        mock_named_resources.keys.return_value = [
-            "p3.2xlarge",
-            "p3.16xlarge",
-            "p4d.24xlarge",
-        ]
+    def test_named_resources_library(self) -> None:
+        lib = _NamedResourcesLibrary()
+        factories: dict[str, Callable[[], Resource]] = {}
+        for name in ["p3.2xlarge", "p3.16xlarge", "p4d.24xlarge"]:
+            factories[name] = mock_resource
+        lib._factories = factories
 
         with self.assertRaisesRegex(
             KeyError,
             "No named resource found for `foo`. Registered named resources:.*",
         ):
-            _ = _NamedResourcesLibrary()["foo"]
+            _ = lib["foo"]
 
         with self.assertRaisesRegex(
             KeyError,
             "No named resource found for `p316xl`. Did you mean `p3.16xlarge`?",
         ):
-            _ = _NamedResourcesLibrary()["p316xl"]
+            _ = lib["p316xl"]
 
     def test_null_and_missing_named_resources(self) -> None:
         self.assertEqual(named_resources["NULL"], NULL_RESOURCE)
         self.assertEqual(named_resources["MISSING"], NULL_RESOURCE)
 
-    def test_custom_named_resources_env_var(self) -> None:
-        import sys
+    def test_keys_and_items(self) -> None:
+        lib = _NamedResourcesLibrary()
+        lib._factories = {"p3.2xlarge": mock_resource}
 
+        self.assertEqual({"p3.2xlarge"}, set(lib.keys()), "keys() must list names")
+        self.assertEqual(
+            [("p3.2xlarge", mock_resource())],
+            list(lib.items()),
+            "items() must materialize each resource",
+        )
+
+    def test_lazy_load_and_reset(self) -> None:
+        lib = _NamedResourcesLibrary()
+        self.assertIsNone(lib._factories, "no discovery may run before first access")
+
+        self.assertIn("NULL", lib)
+
+        self.assertIsNotNone(lib._factories, "first access must populate the cache")
+        lib.reset()
+        self.assertIsNone(lib._factories, "reset() must drop the cache")
+
+    def test_custom_named_resources_env_var(self) -> None:
         mock_module = type(sys)("test_module")
         mock_module.NAMED_RESOURCES = {"test_resource": mock_resource}
 
         with patch.dict(sys.modules, {"test_module": mock_module}):
-            with patch(
-                "torchx.specs.CUSTOM_NAMED_RESOURCES", mock_module.NAMED_RESOURCES
+            with patch.dict(
+                os.environ, {"TORCHX_CUSTOM_NAMED_RESOURCES": "test_module"}
             ):
-                import torchx.specs
+                lib = _NamedResourcesLibrary()
+                self.assertIn("test_resource", lib)
 
-                factories = torchx.specs._load_named_resources()
 
-                self.assertIn("test_resource", factories)
+class LazyDiscoveryTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        for k in [k for k in sys.modules if k.startswith("torchx_plugins")]:
+            del sys.modules[k]
+
+    def test_import_torchx_specs_performs_no_discovery(self) -> None:
+        """`import torchx.specs` must not import plugins or resource modules."""
+        code = "; ".join(
+            [
+                "import sys",
+                "import torchx.specs",
+                "mods = [m for m in sys.modules"
+                " if m.startswith('torchx_plugins')"
+                " or m == 'torchx.specs.named_resources_aws'"
+                " or m == 'torchx.specs.named_resources_generic']",
+                "assert not mods, f'import torchx.specs triggered discovery: {mods}'",
+            ]
+        )
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+        )
+
+    def test_first_lookup_triggers_discovery(self) -> None:
+        lib = _NamedResourcesLibrary()
+        with patch.object(plugins, "registry") as registry_mock:
+            registry_mock.return_value.get.return_value = {}
+            self.assertIsNone(
+                lib._factories, "instantiation must not trigger discovery"
+            )
+            registry_mock.assert_not_called()
+
+            self.assertIn("NULL", lib)
+
+            registry_mock.return_value.get.assert_called_once_with(
+                plugins.PluginType.NAMED_RESOURCE
+            )
+
+    def test_reentrant_plugin_import_scans_clean(self) -> None:
+        """A namespace plugin importing torchx.specs at module top-level is
+        discovered cleanly when discovery is triggered from torchx.specs."""
+        lib = _NamedResourcesLibrary()
+        with patch("sys.path", [_LAZY_FIXTURE_DIR, *sys.path]):
+            plugins.registry().clear()
+            try:
+                self.assertIn(
+                    "reentrant_gpu",
+                    lib,
+                    "plugin with a top-level torchx.specs import must be discovered",
+                )
+                self.assertEqual(
+                    [],
+                    plugins.registry().load_errors(plugins.PluginType.NAMED_RESOURCE),
+                    "re-entrant torchx.specs import must scan clean",
+                )
+            finally:
+                plugins.registry().clear()
+
+    def test_reentrant_lookup_at_import_is_a_load_error(self) -> None:
+        """A plugin looking up a named resource at import time re-enters
+        ``_load`` mid-scan — pinned behavior: the lookup raises
+        ``RuntimeError``, the scanner records the module as a load error,
+        and the outer scan still completes and caches."""
+        with patch("sys.path", [_REENTRANT_LOOKUP_FIXTURE_DIR, *sys.path]):
+            plugins.registry().clear()
+            named_resources.reset()
+            try:
+                self.assertNotIn(
+                    "lookup_at_import_gpu",
+                    named_resources,
+                    "a plugin whose import fails must not be registered",
+                )
+                errors = plugins.registry().load_errors(
+                    plugins.PluginType.NAMED_RESOURCE
+                )
+                self.assertEqual(
+                    1,
+                    len(errors),
+                    f"expected exactly the fixture's load error, got: {errors}",
+                )
+                self.assertIn(
+                    "re-entrant named-resource lookup",
+                    errors[0].error,
+                    "the load error must carry the re-entrancy diagnostic",
+                )
+                self.assertEqual(
+                    NULL_RESOURCE,
+                    named_resources["NULL"],
+                    "the outer scan must complete despite the broken plugin",
+                )
+            finally:
+                plugins.registry().clear()
+                named_resources.reset()
+
+    def test_concurrent_first_lookups_load_once(self) -> None:
+        lib: _NamedResourcesLibrary = _NamedResourcesLibrary()
+        registry_calls: list[int] = []
+
+        def slow_registry() -> MagicMock:
+            registry_calls.append(1)
+            time.sleep(0.1)  # widen the check-then-set window
+            mock = MagicMock()
+            mock.get.return_value = {}
+            return mock
+
+        n = 8
+        barrier: threading.Barrier = threading.Barrier(n)
+        results: list[bool] = []
+
+        def lookup() -> None:
+            barrier.wait()
+            results.append("NULL" in lib)
+
+        with patch.object(plugins, "registry", side_effect=slow_registry):
+            threads = [threading.Thread(target=lookup) for _ in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        self.assertEqual([True] * n, results, "every lookup must see the loaded set")
+        self.assertEqual(
+            1,
+            len(registry_calls),
+            "concurrent first lookups must run discovery exactly once",
+        )

--- a/torchx/specs/test/overlays_test.py
+++ b/torchx/specs/test/overlays_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 import copy
 import json
+import logging
 import os
 import tempfile
 import unittest
@@ -14,11 +15,13 @@ from typing import Any
 
 from torchx.specs import AppDef, Role
 from torchx.specs.overlays import (
+    _FORMAT_KEY,
     _load_overlay_file,
     apply_overlay,
     DEL,
     get_overlay,
     JOIN,
+    OverlaySpec,
     PUT,
     set_overlay,
     validate_overlay,
@@ -382,6 +385,164 @@ class SetGetOverlayTest(unittest.TestCase):
         role = Role(name="w", image="img", entrypoint="e")
         role.metadata["kubernetes"] = 123
         self.assertEqual(get_overlay(role, "kubernetes", "V1Pod"), {})
+
+    def test_set_kind_a_read_kind_b_returns_empty(self) -> None:
+        """Misfire regression: a single kind written via set_overlay must not
+        be handed to a reader asking for a different kind."""
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "mast", "HpcTaskGroupSpec", {"resourceRequirement": {}})
+
+        self.assertEqual(
+            {},
+            get_overlay(role, "mast", "HpcTaskGroupDefinition"),
+            "kind written as HpcTaskGroupSpec must not fall back flat for "
+            "HpcTaskGroupDefinition readers",
+        )
+        # ... while the written kind stays readable
+        self.assertEqual(
+            {"resourceRequirement": {}},
+            get_overlay(role, "mast", "HpcTaskGroupSpec"),
+        )
+
+    def test_marker_survives_set_overlay_merges(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "sched", "JobSpec", {"priority": "high"})
+        set_overlay(role, "sched", "JobSpec", {"oncall": "myoncall"})
+        set_overlay(role, "sched", "JobConfig", {"retries": 3})
+
+        self.assertTrue(
+            role.metadata["sched"][_FORMAT_KEY],
+            "format marker must survive accumulating set_overlay calls",
+        )
+
+    def test_marker_survives_metadata_dict_merge(self) -> None:
+        """apply_overlay-merging two marked namespace dicts keeps the marker."""
+        role_a = Role(name="a", image="img", entrypoint="e")
+        role_b = Role(name="b", image="img", entrypoint="e")
+        set_overlay(role_a, "sched", "JobSpec", {"priority": "high"})
+        set_overlay(role_b, "sched", "JobConfig", {"retries": 3})
+
+        merged = copy.deepcopy(role_a.metadata)
+        apply_overlay(merged, role_b.metadata)
+
+        self.assertTrue(
+            merged["sched"][_FORMAT_KEY],
+            "format marker must survive merging namespace dicts",
+        )
+        role_a.metadata = merged
+        self.assertEqual(
+            {},
+            get_overlay(role_a, "sched", "SomethingElse"),
+            "merged namespace dict must stay nested-only",
+        )
+
+    def test_marked_kind_miss_logs_debug_not_warning(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        set_overlay(role, "sched", "JobSpec", {"priority": "high"})
+
+        with self.assertLogs("torchx.specs.overlays", level="DEBUG") as logs:
+            self.assertEqual({}, get_overlay(role, "sched", "JobConfig"))
+        self.assertTrue(
+            all(r.levelno < logging.WARNING for r in logs.records),
+            "kind miss on a marked namespace is a normal scheduler probe,"
+            " must not warn",
+        )
+        self.assertNotIn(
+            _FORMAT_KEY,
+            "\n".join(logs.output),
+            "format marker must not be listed as an available kind",
+        )
+        self.assertIn("JobSpec", "\n".join(logs.output))
+
+    def test_legacy_unmarked_flat_still_falls_back_with_warning(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        # written via direct metadata access — no marker
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        with self.assertLogs("torchx.specs.overlays", level="WARNING") as logs:
+            overlay = get_overlay(role, "kubernetes", "V1Pod")
+
+        self.assertEqual(
+            {"spec": {"nodeSelector": {"gpu": "true"}}},
+            overlay,
+            "unmarked flat namespace dict must keep the legacy fallback",
+        )
+        self.assertIn("flat", "\n".join(logs.output))
+
+    def test_flat_fallback_false_disables_legacy_fallback(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        self.assertEqual(
+            {},
+            get_overlay(role, "kubernetes", "V1Pod", flat_fallback=False),
+            "flat_fallback=False must never return the flat namespace dict",
+        )
+
+
+class OverlaySpecTest(unittest.TestCase):
+    def test_set_get_round_trip(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+
+        spec.set(role, {"spec": {"nodeSelector": {"gpu": "true"}}})
+        spec.set(role, {"spec": {"tolerations": [{"key": "gpu"}]}})
+
+        self.assertEqual(
+            {
+                "spec": {
+                    "nodeSelector": {"gpu": "true"},
+                    "tolerations": [{"key": "gpu"}],
+                }
+            },
+            spec.get(role),
+            "OverlaySpec.set calls must accumulate like set_overlay",
+        )
+
+    def test_get_missing_returns_empty(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+        self.assertEqual({}, spec.get(role))
+
+    def test_get_never_inherits_flat_namespace(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod")
+        role = Role(name="w", image="img", entrypoint="e")
+        role.metadata["kubernetes"] = {"spec": {"nodeSelector": {"gpu": "true"}}}
+
+        self.assertEqual(
+            {},
+            spec.get(role),
+            "OverlaySpec.get must read nested-format only",
+        )
+
+    def test_blocklist_enforced_on_set(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+        role = Role(name="w", image="img", entrypoint="e")
+
+        with self.assertRaisesRegex(ValueError, "V1Pod.env"):
+            spec.set(role, {"env": {"FOO": "bar"}})
+        self.assertEqual(
+            {},
+            spec.get(role),
+            "a rejected OverlaySpec.set must not store anything",
+        )
+
+    def test_blocklist_enforced_on_get(self) -> None:
+        spec = OverlaySpec("kubernetes", "V1Pod", blocklist=("command", "env"))
+        role = Role(name="w", image="img", entrypoint="e")
+        # write through the raw storage API (bypasses OverlaySpec.set validation)
+        set_overlay(role, "kubernetes", "V1Pod", {"env": {"FOO": "bar"}})
+
+        with self.assertRaisesRegex(ValueError, "V1Pod.env"):
+            spec.get(role)
+
+    def test_reserved_format_marker_kind_rejected(self) -> None:
+        role = Role(name="w", image="img", entrypoint="e")
+
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            set_overlay(role, "kubernetes", _FORMAT_KEY, {"spec": {}})
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            get_overlay(role, "kubernetes", _FORMAT_KEY)
 
 
 # =============================================================================

--- a/torchx/specs/test/reentrant_lookup_fixture/torchx_plugins/named_resources/lookup_at_import.py
+++ b/torchx/specs/test/reentrant_lookup_fixture/torchx_plugins/named_resources/lookup_at_import.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Re-entrancy fixture: a namespace plugin that LOOKS UP a named resource at
+module top-level. Discovery is triggered from inside
+``_NamedResourcesLibrary._load`` (first named-resource lookup), so this
+module's import re-enters ``_load`` mid-scan — pinned behavior: the lookup
+raises ``RuntimeError`` and the scanner records this module as a plugin
+load error."""
+
+from torchx.plugins import register
+from torchx.specs import named_resources
+from torchx.specs.api import Resource
+
+# the re-entrant lookup IS the fixture: raises RuntimeError mid-scan
+_NULL: Resource = named_resources["NULL"]
+
+
+@register.named_resource()
+def lookup_at_import_gpu() -> Resource:
+    return Resource(cpu=1, gpu=1, memMB=1024)


### PR DESCRIPTION
Summary:

`import torchx.specs` eagerly imported the AWS/generic/custom named-resource modules **and ran the full `torchx_plugins` namespace scan** — every process importing the core types paid the discovery cost (and plugin modules importing `torchx.specs` at top-level re-entered a half-initialized module).

**This diff fixes this by** moving all discovery into `_NamedResourcesLibrary._load()` — cached on first lookup, with a `reset()` test hook:

```python
import torchx.specs        # imports nothing beyond core types (proven by test)
torchx.specs.named_resources["gpu"]   # first lookup runs discovery, cached
```

- Merge priority is unchanged: generic < aws < custom < plugins, `NULL`/`MISSING` last.
- Discovery is single-flight (double-checked `RLock`); a re-entrant lookup (a plugin looking up a named resource at import time, mid-scan) raises `RuntimeError`, recorded as that module's plugin load error. Raising beats returning the partially-built mapping: the mid-scan set depends on scan order — silent nondeterminism; failing fast tells the author to defer the lookup into the factory body.
- External consumers migrate off the deleted `_named_resource_factories` global to the new `keys()`/`items()` iteration surface (hpc_comms, vizard, the param_bench + npi_benchmarks try-arms, OSS `advanced.rst`, torchx_plugins' `hasattr`-guarded coexistence test); flint's `constants.py` iterates by name and materializes lazily, preserving its RMUC-factory skip that `items()` would defeat.
- NOTE: the env-var default `"torchx.specs.fb.named_resources"` is deliberately untouched — owned by a later campaign wave.

Reviewed By: athmasagar

Differential Revision: D116126085
