### PR TITLE
(refactor)[4/6][torchx][cli] Uniform runner lifecycle + dedup via AppHandleSubCommand (#1390)

### DIFF
--- a/torchx/cli/cmd_base.py
+++ b/torchx/cli/cmd_base.py
@@ -8,6 +8,14 @@
 
 import abc
 import argparse
+import logging
+import sys
+from typing import NoReturn
+
+from torchx.runner import get_runner, Runner
+from torchx.specs.api import parse_app_handle
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class SubCommand(abc.ABC):
@@ -28,3 +36,37 @@ class SubCommand(abc.ABC):
         Runs the sub command. Parsed arguments are available as ``args``.
         """
         raise NotImplementedError()
+
+
+class AppHandleSubCommand(SubCommand):
+    """Base for subcommands that act on a single ``app_handle`` positional arg
+    (e.g. ``cancel``, ``delete``, ``describe``, ``status``).
+
+    Adds the ``app_handle`` argument and runs :py:meth:`run_with_runner`
+    inside a ``with get_runner()`` block so scheduler clients are closed.
+    """
+
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "app_handle",
+            type=str,
+            help="torchx app handle (e.g. local://session-name/app-id)",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        with get_runner() as runner:
+            self.run_with_runner(args, runner)
+
+    @abc.abstractmethod
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        """Command body; ``runner`` is closed when this returns."""
+        raise NotImplementedError()
+
+    def exit_missing_app(self, app_handle: str) -> NoReturn:
+        """Logs the shared app-not-found error and exits non-zero."""
+        scheduler, _, app_id = parse_app_handle(app_handle)
+        logger.error(
+            f"AppDef: {app_id},"
+            f" does not exist or has been removed from {scheduler}'s data plane"
+        )
+        sys.exit(1)

--- a/torchx/cli/cmd_cancel.py
+++ b/torchx/cli/cmd_cancel.py
@@ -10,21 +10,12 @@
 import argparse
 import logging
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdCancel(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        runner = get_runner()
-        runner.cancel(app_handle)
+class CmdCancel(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        runner.cancel(args.app_handle)

--- a/torchx/cli/cmd_delete.py
+++ b/torchx/cli/cmd_delete.py
@@ -10,21 +10,12 @@
 import argparse
 import logging
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdDelete(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        runner = get_runner()
-        runner.delete(app_handle)
+class CmdDelete(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        runner.delete(args.app_handle)

--- a/torchx/cli/cmd_describe.py
+++ b/torchx/cli/cmd_describe.py
@@ -11,34 +11,18 @@ import argparse
 import dataclasses
 import logging
 import pprint
-import sys
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
-from torchx.specs.api import parse_app_handle
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdDescribe(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
-        app = runner.describe(app_handle)
+class CmdDescribe(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        app = runner.describe(args.app_handle)
 
         if app:
             pprint.pprint(dataclasses.asdict(app), indent=2, width=80)
         else:
-            logger.error(
-                f"AppDef: {app_id},"
-                f" does not exist or has been removed from {scheduler}'s data plane"
-            )
-            sys.exit(1)
+            self.exit_missing_app(args.app_handle)

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -16,7 +16,6 @@ import time
 from queue import Queue
 from typing import TextIO
 
-from torchx import specs
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner, Runner
 from torchx.schedulers.api import Stream
@@ -206,6 +205,12 @@ class CmdLog(SubCommand):
         )
 
     def run(self, args: argparse.Namespace) -> None:
-        get_logs(
-            sys.stdout, args.identifier, args.regex, args.tail, streams=args.streams
-        )
+        with get_runner() as runner:
+            get_logs(
+                sys.stdout,
+                args.identifier,
+                args.regex,
+                args.tail,
+                runner=runner,
+                streams=args.streams,
+            )

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -340,14 +340,14 @@ class CmdRun(SubCommand):
             sys.exit(1)
         except specs.InvalidRunConfigException as e:
             error_msg = (
-                "Invalid scheduler configuration: %s\n"
+                f"Invalid scheduler configuration: {e}\n"
                 "To configure scheduler options, either:\n"
                 "  1. Use the `-cfg` command-line argument, e.g., `-cfg key1=value1,key2=value2`\n"
                 "  2. Set up a `.torchxconfig` file. For more details, visit: https://meta-pytorch.org/torchx/main/runner.config.html\n"
-                "Run `torchx runopts %s` to check all available configuration options for the "
-                "`%s` scheduler."
+                f"Run `torchx runopts {args.scheduler}` to check all available configuration options for the "
+                f"`{args.scheduler}` scheduler."
             )
-            print(error_msg % (e, args.scheduler, args.scheduler), file=sys.stderr)
+            logger.error(error_msg)
             sys.exit(1)
 
     def _run_from_cli_args(self, runner: Runner, args: argparse.Namespace) -> None:

--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -10,11 +10,9 @@
 import argparse
 import json
 import logging
-import sys
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
-from torchx.specs.api import parse_app_handle
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -36,13 +34,9 @@ def parse_list_arg(arg: str) -> list[str] | None:
     return arg.split(",")
 
 
-class CmdStatus(SubCommand):
+class CmdStatus(AppHandleSubCommand):
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
+        super().add_arguments(subparser)
         subparser.add_argument(
             "--roles", type=str, default="", help="comma separated roles to filter"
         )
@@ -52,11 +46,8 @@ class CmdStatus(SubCommand):
             help="output the status in JSON format",
         )
 
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
-        app_status = runner.status(app_handle)
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        app_status = runner.status(args.app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:
             if args.json:
@@ -64,8 +55,4 @@ class CmdStatus(SubCommand):
             else:
                 print(app_status.format(filter_roles))
         else:
-            logger.error(
-                f"AppDef: {app_id},"
-                f" does not exist or has been removed from {scheduler}'s data plane"
-            )
-            sys.exit(1)
+            self.exit_missing_app(args.app_handle)

--- a/torchx/cli/test/cmd_cancel_test.py
+++ b/torchx/cli/test/cmd_cancel_test.py
@@ -26,3 +26,16 @@ class CmdCancelTest(unittest.TestCase):
 
         self.assertEqual(cancel.call_count, 1)
         cancel.assert_called_with("foo://session/id")
+
+    @patch("torchx.runner.api.Runner.close")
+    @patch("torchx.runner.api.Runner.cancel")
+    def test_run_closes_runner(self, cancel: MagicMock, close: MagicMock) -> None:
+        """Pins AppHandleSubCommand's runner lifecycle: `with get_runner()`
+        closes scheduler clients when the command body returns."""
+        parser = argparse.ArgumentParser()
+        cmd_cancel = CmdCancel()
+        cmd_cancel.add_arguments(parser)
+
+        cmd_cancel.run(parser.parse_args(["foo://session/id"]))
+
+        close.assert_called_once()

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import copy
 import json
 import logging
 import os
@@ -341,6 +342,29 @@ class Runner:
         The returned :py:class:`~torchx.specs.AppDryRunInfo` can be
         ``print()``-ed for inspection or passed to :py:meth:`schedule`.
         """
+        # operate on a copy so that the env injection and workspace overwrite
+        # below never leak into the caller's AppDef (one AppDef can be
+        # dry-run multiple times); the copy rides in the returned
+        # AppDryRunInfo's `_app`.
+        #
+        # Role.overrides may already hold non-deepcopyable values (e.g. APF
+        # attaches an in-flight fbpkg Future before calling dryrun), so mirror
+        # the macros.Values.apply pattern: detach overrides, deepcopy, then
+        # attach the SAME dict object to both the original and the copy —
+        # sharing is the intended semantic: resolving an override through
+        # either owner benefits both.
+        detached_overrides = [role.overrides for role in app.roles]
+        for role in app.roles:
+            role.overrides = {}
+        try:
+            app_copy = copy.deepcopy(app)
+        finally:
+            for role, overrides in zip(app.roles, detached_overrides):
+                role.overrides = overrides
+        for role_copy, overrides in zip(app_copy.roles, detached_overrides):
+            role_copy.overrides = overrides
+        app = app_copy
+
         # input validation
         if not app.roles:
             raise ValueError(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import copy
 import datetime
 import os
 from contextlib import contextmanager
@@ -259,9 +261,10 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            scheduler_mock.submit_dryrun.assert_called_once_with(
-                app, {**self.cfg, "foo": "bar"}
-            )
+            scheduler_mock.submit_dryrun.assert_called_once()
+            submitted_app, resolved_cfg = scheduler_mock.submit_dryrun.call_args[0]
+            self.assertEqual(app.name, submitted_app.name)
+            self.assertEqual({**self.cfg, "foo": "bar"}, resolved_cfg)
             scheduler_mock._validate.assert_called_once()
             from torchx.util.session import CURRENT_SESSION_ID
 
@@ -295,10 +298,15 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_JOB_ID],
                     "local_dir://" + SESSION_NAME + "/${app_id}",
+                )
+            for role in app.roles:
+                self.assertNotIn(
+                    ENV_TORCHX_JOB_ID, role.env, "caller's AppDef must not be mutated"
                 )
 
     def test_dryrun_trackers_parent_run_id_as_paramenter(self, _: MagicMock) -> None:
@@ -328,7 +336,8 @@ class RunnerTest(TestWithTmpDir):
             runner.dryrun(
                 app, "local_dir", cfg=self.cfg, parent_run_id=expected_parent_run_id
             )
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_PARENT_RUN_ID],
                     expected_parent_run_id,
@@ -369,7 +378,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -419,7 +429,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -432,6 +443,78 @@ class RunnerTest(TestWithTmpDir):
                     role.env["TORCHX_TRACKER_MY_TRACKER2_CONFIG"],
                     expected_tracker2_config,
                 )
+
+    def test_dryrun_does_not_mutate_caller_appdef(self, _: MagicMock) -> None:
+        sched1_mock = MagicMock()
+        sched2_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched1": lambda session_name, **kwargs: sched1_mock,
+                "sched2": lambda session_name, **kwargs: sched2_mock,
+            },
+        ) as runner:
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role])
+            pristine_app = copy.deepcopy(app)
+
+            runner.dryrun(app, "sched1", cfg=self.cfg)
+            runner.dryrun(app, "sched2", cfg=self.cfg)
+
+            self.assertEqual(
+                pristine_app, app, "dryrun must not mutate the caller's AppDef"
+            )
+            # each dryrun's env injection lands on the submitted copy
+            for scheduler, scheduler_mock in [
+                ("sched1", sched1_mock),
+                ("sched2", sched2_mock),
+            ]:
+                submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+                self.assertEqual(
+                    f"{scheduler}://{SESSION_NAME}/${{app_id}}",
+                    submitted_app.roles[0].env[ENV_TORCHX_JOB_ID],
+                )
+
+    def test_dryrun_with_non_deepcopyable_overrides(self, _: MagicMock) -> None:
+        """Role.overrides may hold values deepcopy chokes on (e.g. an APF
+        fbpkg Future attached before dryrun); dryrun must succeed and the
+        submitted copy must SHARE the overrides dict with the caller's role
+        so a resolution through either side benefits both."""
+        sched_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched": lambda session_name, **kwargs: sched_mock,
+            },
+        ) as runner:
+            future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+                overrides={"image": future, "entrypoint": lambda: "echo"},
+            )
+            app = AppDef("name", roles=[role])
+
+            runner.dryrun(app, "sched", cfg=self.cfg)
+
+            submitted_role = sched_mock.submit_dryrun.call_args[0][0].roles[0]
+            self.assertIs(
+                role.overrides,
+                submitted_role.overrides,
+                "the copy must share the caller's overrides dict",
+            )
+            self.assertIsNot(
+                role, submitted_role, "dryrun must still operate on a role copy"
+            )
 
     def test_dryrun_with_workspace(self, _: MagicMock) -> None:
         class TestScheduler(WorkspaceMixin[None], Scheduler):
@@ -572,7 +655,13 @@ class RunnerTest(TestWithTmpDir):
             app = AppDef("sleeper", roles=[role], metadata=metadata)
 
             app_handle = runner.run(app, scheduler="local_dir", cfg=self.cfg)
-            self.assertEqual(app, runner.describe(app_handle))
+            described = none_throws(runner.describe(app_handle))
+            # describe() returns the submitted copy which additionally carries
+            # the runner's env injection (TORCHX_*) and scheduler-side env
+            # tweaks (e.g. local scheduler's PATH prepend); ignore env
+            for role in described.roles:
+                role.env.clear()
+            self.assertEqual(app, described)
             # unknown app should return None
             self.assertIsNone(runner.describe("local_dir://session1/unknown_app"))
 

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -70,6 +70,15 @@ def _create_args_parser_from_parameters(
             values: Any,
             option_string: str | None = None,
         ) -> None:
+            if (
+                len(values) == 0
+                and getattr(namespace, self.dest, None) is not self.default
+            ):
+                # REMAINDER actions fire even when no varargs were passed on the
+                # CLI; keep a pre-seeded namespace attr (e.g. the cli_unset
+                # sentinel in parse_args) intact so an empty CLI is not
+                # mistaken for an explicitly passed empty varargs list
+                return
             setattr(
                 namespace,
                 self.dest,
@@ -116,10 +125,12 @@ def _create_args_parser_from_parameters(
 
 
 def _merge_config_values_with_args(
-    parsed_args: argparse.Namespace, config: dict[str, Any]
+    parsed_args: argparse.Namespace, config: dict[str, Any], cli_set_args: set[str]
 ) -> None:
+    """Fills ``parsed_args`` with ``config`` values for the args that were not
+    explicitly passed on the CLI (config overrides defaults, never CLI args)."""
     for key, val in config.items():
-        if key in parsed_args:
+        if key in parsed_args and key not in cli_set_args:
             setattr(parsed_args, key, val)
 
 
@@ -132,6 +143,9 @@ def parse_args(
     """
     Parse passed arguments, defaults, and config values into a namespace for
     a component function.
+
+    Precedence (high -> low): explicitly passed ``cmpnt_args`` > ``config`` >
+    ``cmpnt_defaults`` > defaults declared on the fn signature.
 
     Args:
     cmpnt_fn: Component function
@@ -147,7 +161,20 @@ def parse_args(
     script_parser = _create_args_parser(cmpnt_fn, cmpnt_defaults, config)
     parsed_args = script_parser.parse_args(cmpnt_args)
     if config:
-        _merge_config_values_with_args(parsed_args, config)
+        # re-parse onto a sentinel-seeded namespace: argparse applies defaults
+        # only for attrs missing from the given namespace, so attrs still
+        # holding the sentinel afterwards were NOT explicitly passed on the CLI
+        cli_unset = object()
+        seeded_namespace = Namespace(
+            **dict.fromkeys(inspect.signature(cmpnt_fn).parameters, cli_unset)
+        )
+        script_parser.parse_args(cmpnt_args, namespace=seeded_namespace)
+        cli_set_args = {
+            name
+            for name, value in vars(seeded_namespace).items()
+            if value is not cli_unset
+        }
+        _merge_config_values_with_args(parsed_args, config, cli_set_args)
 
     return parsed_args
 

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -23,6 +23,7 @@ from torchx.specs.builders import (
     DeviceMount,
     make_app_handle,
     materialize_appdef,
+    parse_args,
     parse_mounts,
     VolumeMount,
 )
@@ -53,6 +54,84 @@ def get_dummy_application(role: str) -> AppDef:
 def example_empty_fn() -> AppDef:
     """Empty function that returns dummy app"""
     return get_dummy_application("trainer")
+
+
+def example_fn_for_config(
+    foo: str = "declared_foo", bar: int = 1, baz: str = "declared_baz"
+) -> AppDef:
+    """Dummy app parameterized by foo, bar, baz
+
+    Args:
+        foo: foo param
+        bar: bar param
+        baz: baz param
+    """
+    return get_dummy_application("trainer")
+
+
+class ParseArgsConfigPrecedenceTest(unittest.TestCase):
+    def test_cli_args_beat_config_values(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            ["--foo", "from_cli"],
+            config={"foo": "from_config", "bar": 2},
+        )
+        self.assertEqual(
+            "from_cli", parsed.foo, "explicitly passed CLI arg must win over config"
+        )
+        self.assertEqual(2, parsed.bar, "config must fill args not passed on the CLI")
+        self.assertEqual(
+            "declared_baz",
+            parsed.baz,
+            "declared default must be kept when neither CLI nor config set the arg",
+        )
+
+    def test_config_beats_cmpnt_defaults(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            [],
+            cmpnt_defaults={"foo": "from_cmpnt_defaults"},
+            config={"foo": "from_config"},
+        )
+        self.assertEqual(
+            "from_config", parsed.foo, "config must win over cmpnt_defaults"
+        )
+
+    def test_config_fills_varargs_on_empty_cli(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["cfg1", "cfg2"],
+            parsed.args,
+            "config must fill *args when no varargs were passed on the CLI",
+        )
+
+    def test_cli_varargs_beat_config(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval", "arg1", "arg2"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["arg1", "arg2"],
+            parsed.args,
+            "explicitly passed CLI varargs must win over config",
+        )
+
+    def test_cli_args_beat_config_via_materialize_appdef(self) -> None:
+        app = materialize_appdef(
+            example_fn_with_bool,
+            ["--flag", "True"],
+            config={"flag": False},
+        )
+        self.assertEqual(
+            "trainer-with-flag",
+            app.roles[0].name,
+            "explicitly passed CLI arg must win over config",
+        )
 
 
 def example_fn_with_bool(flag: bool = False) -> AppDef:

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -96,10 +96,6 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
         updates ``role.image`` with the resulting image id.
         """
 
-        old_imgs = [
-            image.id
-            for image in self._docker_client.images.list(name=cfg["image_repo"])
-        ]
         context = _build_context(role.image, workspace)
 
         try:
@@ -136,9 +132,8 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
                     image_id = aux["ID"]
                 if error := event.get("error"):
                     raise BuildError(reason=error, build_log=None)
-            if len(old_imgs) == 0 or role.image not in old_imgs:
-                assert image_id, "image id was not found"
-                role.image = image_id
+            assert image_id, "image id was not found"
+            role.image = image_id
 
         finally:
             context.close()

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -153,6 +153,31 @@ class DockerWorkspaceMockTest(unittest.TestCase):
         self.assertEqual(mock_log.info.call_count, 2)
 
     @patch("torchx.workspace.docker_workspace.log")
+    def test_build_updates_role_image_even_if_current_image_in_repo(
+        self, mock_log: MagicMock
+    ) -> None:
+        client = MagicMock()
+        image_id = "sha256:new_build"
+        client.api.build.return_value = [{"aux": {"ID": image_id}}]
+        # role.image is an image id currently tagged under image_repo — the
+        # scenario where the old `old_imgs` guard silently discarded the build
+        old_image = MagicMock()
+        old_image.id = "sha256:old_build"
+        client.images.list.return_value = [old_image]
+        workspace = DockerWorkspaceMixin(docker_client=client)
+        role = Role(name="b", image="sha256:old_build")
+        workspace.build_workspace_and_update_role(
+            role=role,
+            workspace="bogus",
+            cfg={"image_repo": "example.com/repo", "quiet": "true"},
+        )
+        self.assertEqual(
+            image_id,
+            role.image,
+            "a successful build must always stamp the built image onto the role",
+        )
+
+    @patch("torchx.workspace.docker_workspace.log")
     def test_build_workspace_and_update_raises_error(self, mock_log: MagicMock) -> None:
         client = MagicMock()
         img = MagicMock()


### PR DESCRIPTION
Summary:

`torchx cancel/delete/describe/status/log` each built a `Runner` with bare `get_runner()` and never closed it, **leaking scheduler clients on every invocation** (only `torchx run` used `with get_runner()`), and four commands carried verbatim-duplicate bodies. This diff adds `AppHandleSubCommand` to `cmd_base` — it owns the shared `app_handle` positional arg, wraps the command body (`run_with_runner`) in `with get_runner()`, and hosts the shared app-not-found error+exit — and rebases cancel/delete (previously identical modulo the runner method) and describe/status (identical error path) onto it. `CmdLog` opens its runner via the same `with` pattern and passes it into `get_logs`.

Riders: `cmd_run`'s `InvalidRunConfigException` handler switches from raw `print(..., file=sys.stderr)` + `%`-format to `logger.error` + f-string — the convention every other error path in the module already uses. Drops `cmd_log`'s unused `torchx import specs`.

NOTE: fb-side `FBCmdCancel`/`FBCmdStatus` override `run()` wholesale and inherit only `add_arguments` — unaffected. Pre-existing dead constants in `cmd_status.py` (`_ROLE_FORMAT_TEMPLATE`, `_REPLICA_FORMAT_TEMPLATE_DETAILED`, `_LINE_WIDTH`) left for a later cleanup wave. Autodeps' proposed `//torchx/runner:lib` addition to `cli:lib_core` rejected per the `manual` NOT-":lib" pin (D116073135 fixes the churn).

Reviewed By: athmasagar

Differential Revision: D116153348
