### PR TITLE
(refactor)[5/6][torchx][slurm] Migrate SlurmOpts to a StructuredOpts dataclass (#1391)

### DIFF
--- a/torchx/cli/cmd_base.py
+++ b/torchx/cli/cmd_base.py
@@ -8,6 +8,14 @@
 
 import abc
 import argparse
+import logging
+import sys
+from typing import NoReturn
+
+from torchx.runner import get_runner, Runner
+from torchx.specs.api import parse_app_handle
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class SubCommand(abc.ABC):
@@ -28,3 +36,37 @@ class SubCommand(abc.ABC):
         Runs the sub command. Parsed arguments are available as ``args``.
         """
         raise NotImplementedError()
+
+
+class AppHandleSubCommand(SubCommand):
+    """Base for subcommands that act on a single ``app_handle`` positional arg
+    (e.g. ``cancel``, ``delete``, ``describe``, ``status``).
+
+    Adds the ``app_handle`` argument and runs :py:meth:`run_with_runner`
+    inside a ``with get_runner()`` block so scheduler clients are closed.
+    """
+
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "app_handle",
+            type=str,
+            help="torchx app handle (e.g. local://session-name/app-id)",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        with get_runner() as runner:
+            self.run_with_runner(args, runner)
+
+    @abc.abstractmethod
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        """Command body; ``runner`` is closed when this returns."""
+        raise NotImplementedError()
+
+    def exit_missing_app(self, app_handle: str) -> NoReturn:
+        """Logs the shared app-not-found error and exits non-zero."""
+        scheduler, _, app_id = parse_app_handle(app_handle)
+        logger.error(
+            f"AppDef: {app_id},"
+            f" does not exist or has been removed from {scheduler}'s data plane"
+        )
+        sys.exit(1)

--- a/torchx/cli/cmd_cancel.py
+++ b/torchx/cli/cmd_cancel.py
@@ -10,21 +10,12 @@
 import argparse
 import logging
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdCancel(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        runner = get_runner()
-        runner.cancel(app_handle)
+class CmdCancel(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        runner.cancel(args.app_handle)

--- a/torchx/cli/cmd_delete.py
+++ b/torchx/cli/cmd_delete.py
@@ -10,21 +10,12 @@
 import argparse
 import logging
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdDelete(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        runner = get_runner()
-        runner.delete(app_handle)
+class CmdDelete(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        runner.delete(args.app_handle)

--- a/torchx/cli/cmd_describe.py
+++ b/torchx/cli/cmd_describe.py
@@ -11,34 +11,18 @@ import argparse
 import dataclasses
 import logging
 import pprint
-import sys
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
-from torchx.specs.api import parse_app_handle
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class CmdDescribe(SubCommand):
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
-        app = runner.describe(app_handle)
+class CmdDescribe(AppHandleSubCommand):
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        app = runner.describe(args.app_handle)
 
         if app:
             pprint.pprint(dataclasses.asdict(app), indent=2, width=80)
         else:
-            logger.error(
-                f"AppDef: {app_id},"
-                f" does not exist or has been removed from {scheduler}'s data plane"
-            )
-            sys.exit(1)
+            self.exit_missing_app(args.app_handle)

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -16,7 +16,6 @@ import time
 from queue import Queue
 from typing import TextIO
 
-from torchx import specs
 from torchx.cli.cmd_base import SubCommand
 from torchx.runner import get_runner, Runner
 from torchx.schedulers.api import Stream
@@ -206,6 +205,12 @@ class CmdLog(SubCommand):
         )
 
     def run(self, args: argparse.Namespace) -> None:
-        get_logs(
-            sys.stdout, args.identifier, args.regex, args.tail, streams=args.streams
-        )
+        with get_runner() as runner:
+            get_logs(
+                sys.stdout,
+                args.identifier,
+                args.regex,
+                args.tail,
+                runner=runner,
+                streams=args.streams,
+            )

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -340,14 +340,14 @@ class CmdRun(SubCommand):
             sys.exit(1)
         except specs.InvalidRunConfigException as e:
             error_msg = (
-                "Invalid scheduler configuration: %s\n"
+                f"Invalid scheduler configuration: {e}\n"
                 "To configure scheduler options, either:\n"
                 "  1. Use the `-cfg` command-line argument, e.g., `-cfg key1=value1,key2=value2`\n"
                 "  2. Set up a `.torchxconfig` file. For more details, visit: https://meta-pytorch.org/torchx/main/runner.config.html\n"
-                "Run `torchx runopts %s` to check all available configuration options for the "
-                "`%s` scheduler."
+                f"Run `torchx runopts {args.scheduler}` to check all available configuration options for the "
+                f"`{args.scheduler}` scheduler."
             )
-            print(error_msg % (e, args.scheduler, args.scheduler), file=sys.stderr)
+            logger.error(error_msg)
             sys.exit(1)
 
     def _run_from_cli_args(self, runner: Runner, args: argparse.Namespace) -> None:

--- a/torchx/cli/cmd_status.py
+++ b/torchx/cli/cmd_status.py
@@ -10,11 +10,9 @@
 import argparse
 import json
 import logging
-import sys
 
-from torchx.cli.cmd_base import SubCommand
-from torchx.runner import get_runner
-from torchx.specs.api import parse_app_handle
+from torchx.cli.cmd_base import AppHandleSubCommand
+from torchx.runner import Runner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -36,13 +34,9 @@ def parse_list_arg(arg: str) -> list[str] | None:
     return arg.split(",")
 
 
-class CmdStatus(SubCommand):
+class CmdStatus(AppHandleSubCommand):
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "app_handle",
-            type=str,
-            help="torchx app handle (e.g. local://session-name/app-id)",
-        )
+        super().add_arguments(subparser)
         subparser.add_argument(
             "--roles", type=str, default="", help="comma separated roles to filter"
         )
@@ -52,11 +46,8 @@ class CmdStatus(SubCommand):
             help="output the status in JSON format",
         )
 
-    def run(self, args: argparse.Namespace) -> None:
-        app_handle = args.app_handle
-        scheduler, _, app_id = parse_app_handle(app_handle)
-        runner = get_runner()
-        app_status = runner.status(app_handle)
+    def run_with_runner(self, args: argparse.Namespace, runner: Runner) -> None:
+        app_status = runner.status(args.app_handle)
         filter_roles = parse_list_arg(args.roles)
         if app_status:
             if args.json:
@@ -64,8 +55,4 @@ class CmdStatus(SubCommand):
             else:
                 print(app_status.format(filter_roles))
         else:
-            logger.error(
-                f"AppDef: {app_id},"
-                f" does not exist or has been removed from {scheduler}'s data plane"
-            )
-            sys.exit(1)
+            self.exit_missing_app(args.app_handle)

--- a/torchx/cli/test/cmd_cancel_test.py
+++ b/torchx/cli/test/cmd_cancel_test.py
@@ -26,3 +26,16 @@ class CmdCancelTest(unittest.TestCase):
 
         self.assertEqual(cancel.call_count, 1)
         cancel.assert_called_with("foo://session/id")
+
+    @patch("torchx.runner.api.Runner.close")
+    @patch("torchx.runner.api.Runner.cancel")
+    def test_run_closes_runner(self, cancel: MagicMock, close: MagicMock) -> None:
+        """Pins AppHandleSubCommand's runner lifecycle: `with get_runner()`
+        closes scheduler clients when the command body returns."""
+        parser = argparse.ArgumentParser()
+        cmd_cancel = CmdCancel()
+        cmd_cancel.add_arguments(parser)
+
+        cmd_cancel.run(parser.parse_args(["foo://session/id"]))
+
+        close.assert_called_once()

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import copy
 import json
 import logging
 import os
@@ -341,6 +342,29 @@ class Runner:
         The returned :py:class:`~torchx.specs.AppDryRunInfo` can be
         ``print()``-ed for inspection or passed to :py:meth:`schedule`.
         """
+        # operate on a copy so that the env injection and workspace overwrite
+        # below never leak into the caller's AppDef (one AppDef can be
+        # dry-run multiple times); the copy rides in the returned
+        # AppDryRunInfo's `_app`.
+        #
+        # Role.overrides may already hold non-deepcopyable values (e.g. APF
+        # attaches an in-flight fbpkg Future before calling dryrun), so mirror
+        # the macros.Values.apply pattern: detach overrides, deepcopy, then
+        # attach the SAME dict object to both the original and the copy —
+        # sharing is the intended semantic: resolving an override through
+        # either owner benefits both.
+        detached_overrides = [role.overrides for role in app.roles]
+        for role in app.roles:
+            role.overrides = {}
+        try:
+            app_copy = copy.deepcopy(app)
+        finally:
+            for role, overrides in zip(app.roles, detached_overrides):
+                role.overrides = overrides
+        for role_copy, overrides in zip(app_copy.roles, detached_overrides):
+            role_copy.overrides = overrides
+        app = app_copy
+
         # input validation
         if not app.roles:
             raise ValueError(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import copy
 import datetime
 import os
 from contextlib import contextmanager
@@ -259,9 +261,10 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            scheduler_mock.submit_dryrun.assert_called_once_with(
-                app, {**self.cfg, "foo": "bar"}
-            )
+            scheduler_mock.submit_dryrun.assert_called_once()
+            submitted_app, resolved_cfg = scheduler_mock.submit_dryrun.call_args[0]
+            self.assertEqual(app.name, submitted_app.name)
+            self.assertEqual({**self.cfg, "foo": "bar"}, resolved_cfg)
             scheduler_mock._validate.assert_called_once()
             from torchx.util.session import CURRENT_SESSION_ID
 
@@ -295,10 +298,15 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_JOB_ID],
                     "local_dir://" + SESSION_NAME + "/${app_id}",
+                )
+            for role in app.roles:
+                self.assertNotIn(
+                    ENV_TORCHX_JOB_ID, role.env, "caller's AppDef must not be mutated"
                 )
 
     def test_dryrun_trackers_parent_run_id_as_paramenter(self, _: MagicMock) -> None:
@@ -328,7 +336,8 @@ class RunnerTest(TestWithTmpDir):
             runner.dryrun(
                 app, "local_dir", cfg=self.cfg, parent_run_id=expected_parent_run_id
             )
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_PARENT_RUN_ID],
                     expected_parent_run_id,
@@ -369,7 +378,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -419,7 +429,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -432,6 +443,78 @@ class RunnerTest(TestWithTmpDir):
                     role.env["TORCHX_TRACKER_MY_TRACKER2_CONFIG"],
                     expected_tracker2_config,
                 )
+
+    def test_dryrun_does_not_mutate_caller_appdef(self, _: MagicMock) -> None:
+        sched1_mock = MagicMock()
+        sched2_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched1": lambda session_name, **kwargs: sched1_mock,
+                "sched2": lambda session_name, **kwargs: sched2_mock,
+            },
+        ) as runner:
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role])
+            pristine_app = copy.deepcopy(app)
+
+            runner.dryrun(app, "sched1", cfg=self.cfg)
+            runner.dryrun(app, "sched2", cfg=self.cfg)
+
+            self.assertEqual(
+                pristine_app, app, "dryrun must not mutate the caller's AppDef"
+            )
+            # each dryrun's env injection lands on the submitted copy
+            for scheduler, scheduler_mock in [
+                ("sched1", sched1_mock),
+                ("sched2", sched2_mock),
+            ]:
+                submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+                self.assertEqual(
+                    f"{scheduler}://{SESSION_NAME}/${{app_id}}",
+                    submitted_app.roles[0].env[ENV_TORCHX_JOB_ID],
+                )
+
+    def test_dryrun_with_non_deepcopyable_overrides(self, _: MagicMock) -> None:
+        """Role.overrides may hold values deepcopy chokes on (e.g. an APF
+        fbpkg Future attached before dryrun); dryrun must succeed and the
+        submitted copy must SHARE the overrides dict with the caller's role
+        so a resolution through either side benefits both."""
+        sched_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched": lambda session_name, **kwargs: sched_mock,
+            },
+        ) as runner:
+            future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+                overrides={"image": future, "entrypoint": lambda: "echo"},
+            )
+            app = AppDef("name", roles=[role])
+
+            runner.dryrun(app, "sched", cfg=self.cfg)
+
+            submitted_role = sched_mock.submit_dryrun.call_args[0][0].roles[0]
+            self.assertIs(
+                role.overrides,
+                submitted_role.overrides,
+                "the copy must share the caller's overrides dict",
+            )
+            self.assertIsNot(
+                role, submitted_role, "dryrun must still operate on a role copy"
+            )
 
     def test_dryrun_with_workspace(self, _: MagicMock) -> None:
         class TestScheduler(WorkspaceMixin[None], Scheduler):
@@ -572,7 +655,13 @@ class RunnerTest(TestWithTmpDir):
             app = AppDef("sleeper", roles=[role], metadata=metadata)
 
             app_handle = runner.run(app, scheduler="local_dir", cfg=self.cfg)
-            self.assertEqual(app, runner.describe(app_handle))
+            described = none_throws(runner.describe(app_handle))
+            # describe() returns the submitted copy which additionally carries
+            # the runner's env injection (TORCHX_*) and scheduler-side env
+            # tweaks (e.g. local scheduler's PATH prepend); ignore env
+            for role in described.roles:
+                role.env.clear()
+            self.assertEqual(app, described)
             # unknown app should return None
             self.assertIsNone(runner.describe("local_dir://session1/unknown_app"))
 

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -87,6 +87,9 @@ class StructuredOpts(Mapping[str, CfgVal]):
         - Auto-generates ``runopts`` from dataclass fields via :py:meth:`as_runopts`
         - Parses raw config dicts into typed instances via :py:meth:`from_cfg`
         - Supports snake_case field names with camelCase aliases
+        - Field metadata ``cfg_key`` overrides the external config key for
+          names that cannot be field names (e.g. hyphenated ``mail-user``):
+          ``mail_user: str | None = field(default=None, metadata={"cfg_key": "mail-user"})``
         - Extracts help text from field docstrings
         - Supports nested ``StructuredOpts`` fields, flattened with dot-prefixed
           keys (e.g., ``k8s.context``)
@@ -144,7 +147,10 @@ class StructuredOpts(Mapping[str, CfgVal]):
                     kwargs[name] = field_type.from_cfg({})
                 continue
 
-            if name in cfg:
+            cfg_key = f.metadata.get("cfg_key", name)
+            if cfg_key in cfg:
+                kwargs[name] = cfg[cfg_key]
+            elif name in cfg:
                 kwargs[name] = cfg[name]
             else:
                 camel_case = cases.snake_to_camel(name)
@@ -182,6 +188,10 @@ class StructuredOpts(Mapping[str, CfgVal]):
         snake_key = cases.camel_to_snake(key)
         if hasattr(self, snake_key):
             return getattr(self, snake_key)
+        # pyrefly: ignore [bad-argument-type]
+        for f in fields(self):
+            if f.metadata.get("cfg_key") == key:
+                return getattr(self, f.name)
         raise KeyError(key) from None
 
     def __len__(self) -> int:
@@ -198,7 +208,7 @@ class StructuredOpts(Mapping[str, CfgVal]):
                     for nested_key in nested:
                         yield f"{f.name}.{nested_key}"
             else:
-                yield f.name
+                yield f.metadata.get("cfg_key", f.name)
 
     # pyre-fixme[14]: Inconsistent override - Mapping uses PyreReadOnly[object]
     def __contains__(self, key: object) -> bool:
@@ -220,9 +230,10 @@ class StructuredOpts(Mapping[str, CfgVal]):
             return docstrings
 
         # Match: field_name: type...\n    """docstring"""
+        # (non-greedy body so docstrings may contain single/double quotes)
         pattern = re.compile(
-            r'^\s+(\w+):\s*[^\n]+\n\s+"""([^"]+)"""',
-            re.MULTILINE,
+            r'^\s+(\w+):\s*[^\n]+\n\s+"""(.+?)"""',
+            re.MULTILINE | re.DOTALL,
         )
         for match in pattern.finditer(source):
             field_name = match.group(1)
@@ -284,7 +295,7 @@ class StructuredOpts(Mapping[str, CfgVal]):
             required = not has_default and not has_default_factory
 
             opts.add(
-                name,
+                f.metadata.get("cfg_key", name),
                 type_=type_,
                 # pyrefly: ignore [bad-argument-type]
                 default=default,

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -20,10 +20,10 @@ import shlex
 import subprocess
 import tempfile
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from subprocess import CalledProcessError, PIPE
-from typing import Any, Iterable, List, Mapping, TypedDict
+from typing import Any, Iterable, List, Mapping
 
 import torchx
 from torchx.schedulers.api import (
@@ -33,6 +33,7 @@ from torchx.schedulers.api import (
     Scheduler,
     split_lines_iterator,
     Stream,
+    StructuredOpts,
 )
 from torchx.schedulers.local_scheduler import LogIterator
 from torchx.specs import (
@@ -133,19 +134,6 @@ def _should_use_gpus_per_node_from_version() -> bool:
     )  # Major version is equal and minor version is greater or equal
 
 
-SBATCH_JOB_OPTIONS = {
-    "comment",
-    "mail-user",
-    "mail-type",
-    "account",
-}
-SBATCH_GROUP_OPTIONS = {
-    "partition",
-    "time",
-    "constraint",
-    "qos",
-}
-
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -158,22 +146,41 @@ def _apply_app_id_env(s: str) -> str:
     return '"$SLURM_JOB_ID"'.join(escaped_parts)
 
 
-# Using old typed dict syntax to handle hyphenated params
-SlurmOpts = TypedDict(
-    "SlurmOpts",
-    {
-        "account": str | None,
-        "partition": str,
-        "time": str,
-        "comment": str | None,
-        "constraint": str | None,
-        "mail-user": str | None,
-        "mail-type": str | None,
-        "job_dir": str | None,
-        "qos": str | None,
-    },
-    total=False,
-)
+@dataclass
+class SlurmOpts(StructuredOpts):
+    """Typed configuration options for SlurmScheduler."""
+
+    account: str | None = None
+    """The account to use for the slurm job."""
+
+    partition: str | None = None
+    """The partition to run the job in."""
+
+    time: str | None = None
+    """The maximum time the job is allowed to run for. Formats: "minutes",
+    "minutes:seconds", "hours:minutes:seconds", "days-hours",
+    "days-hours:minutes" or "days-hours:minutes:seconds"
+    """
+
+    comment: str | None = None
+    """Comment to set on the slurm job."""
+
+    constraint: str | None = None
+    """Constraint to use for the slurm job."""
+
+    mail_user: str | None = field(default=None, metadata={"cfg_key": "mail-user"})
+    """User to mail on job end."""
+
+    mail_type: str | None = field(default=None, metadata={"cfg_key": "mail-type"})
+    """What events to mail users on."""
+
+    job_dir: str | None = None
+    """The directory to place the job code and outputs. The
+    directory must not exist and will be created. To enable log
+    iteration, jobs will be tracked in ``.torchxslurmjobdirs``."""
+
+    qos: str | None = None
+    """Quality of Service (QoS) to assign to the job."""
 
 
 @dataclass
@@ -204,10 +211,15 @@ class SlurmReplicaRequest:
         sbatch_opts: dict[str, str | None] = {
             "requeue": None,
         }
-        for k, v in cfg.items():
-            if v is None:
-                continue
-            if k in SBATCH_GROUP_OPTIONS:
+        # sbatch options that apply per heterogeneous job group
+        group_opts = {
+            "partition": cfg.partition,
+            "time": cfg.time,
+            "constraint": cfg.constraint,
+            "qos": cfg.qos,
+        }
+        for k, v in group_opts.items():
+            if v is not None:
                 sbatch_opts[k] = str(v)
         sbatch_opts.setdefault("ntasks-per-node", "1")
         resource = role.resource
@@ -339,7 +351,7 @@ fi
 {self.materialize()}"""
 
 
-class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
+class SlurmScheduler(DirWorkspaceMixin, Scheduler[Mapping[str, CfgVal]]):
     """
     SlurmScheduler is a TorchX scheduling interface to slurm. TorchX expects
     that slurm CLI tools are locally installed and job accounting is enabled.
@@ -407,61 +419,7 @@ class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
         super().__init__("slurm", session_name)
 
     def _run_opts(self) -> runopts:
-        opts = runopts()
-        opts.add(
-            "account",
-            type_=str,
-            help="The account to use for the slurm job.",
-            default=None,
-        )
-        opts.add(
-            "partition",
-            type_=str,
-            help="The partition to run the job in.",
-            default=None,
-        )
-        opts.add(
-            "time",
-            type_=str,
-            default=None,
-            help='The maximum time the job is allowed to run for. Formats: \
-            "minutes", "minutes:seconds", "hours:minutes:seconds", "days-hours", \
-            "days-hours:minutes" or "days-hours:minutes:seconds"',
-        )
-        opts.add(
-            "comment",
-            type_=str,
-            help="Comment to set on the slurm job.",
-        )
-        opts.add(
-            "constraint",
-            type_=str,
-            help="Constraint to use for the slurm job.",
-        )
-        opts.add(
-            "mail-user",
-            type_=str,
-            help="User to mail on job end.",
-        )
-        opts.add(
-            "mail-type",
-            type_=str,
-            help="What events to mail users on.",
-        )
-        opts.add(
-            "job_dir",
-            type_=str,
-            help="""The directory to place the job code and outputs. The
-            directory must not exist and will be created. To enable log
-            iteration, jobs will be tracked in ``.torchxslurmjobdirs``.
-            """,
-        )
-        opts.add(
-            "qos",
-            type_=str,
-            help="Quality of Service (QoS) to assign to the job.",
-        )
-        return opts
+        return SlurmOpts.as_runopts()
 
     def schedule(self, dryrun_info: AppDryRunInfo[SlurmBatchRequest]) -> str:
         req = dryrun_info.request
@@ -516,17 +474,14 @@ class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
         return None
 
     def _submit_dryrun(
-        self, app: AppDef, cfg: SlurmOpts
+        self, app: AppDef, cfg: Mapping[str, CfgVal]
     ) -> AppDryRunInfo[SlurmBatchRequest]:
-        job_dir = cfg.get("job_dir")
-        assert job_dir is None or isinstance(job_dir, str), "job_dir must be str"
-
-        partition = cfg.get("partition")
-        assert partition is None or isinstance(partition, str), "partition must be str"
+        # Convert to typed opts for attribute access (resolve() passes a raw dict)
+        opts = cfg if isinstance(cfg, SlurmOpts) else SlurmOpts.from_cfg(cfg)
 
         # check if the partition has at least 1GB memory, if we're not sure,
         # default to using memory allocations
-        memmb = self._partition_memmb(partition)
+        memmb = self._partition_memmb(opts.partition)
         nomem = memmb is not None and memmb <= 1000
 
         replicas = {}
@@ -543,27 +498,32 @@ class SlurmScheduler(DirWorkspaceMixin, Scheduler[SlurmOpts]):
                 replicas[name] = SlurmReplicaRequest.from_role(
                     name,
                     replica_role,
-                    cfg,
+                    opts,
                     nomem=nomem,
                 )
         cmd = ["sbatch", "--parsable"]
 
-        for k in SBATCH_JOB_OPTIONS:
-            # pyre-fixme: Typed Dict requires string literal
-            if k in cfg and cfg[k] is not None:
-                # pyre-fixme: Typed Dict requires string literal
-                cmd += [f"--{k}={cfg[k]}"]
+        # sbatch options that apply once to the whole job
+        job_opts = {
+            "comment": opts.comment,
+            "mail-user": opts.mail_user,
+            "mail-type": opts.mail_type,
+            "account": opts.account,
+        }
+        for k, v in job_opts.items():
+            if v is not None:
+                cmd += [f"--{k}={v}"]
 
         req = SlurmBatchRequest(
             cmd=cmd,
             replicas=replicas,
-            job_dir=job_dir,
+            job_dir=opts.job_dir,
             max_retries=min(role.max_retries for role in app.roles),
         )
 
         return AppDryRunInfo(req, repr)
 
-    def _validate(self, app: AppDef, scheduler: str, cfg: SlurmOpts) -> None:
+    def _validate(self, app: AppDef, scheduler: str, cfg: Mapping[str, CfgVal]) -> None:
         # Skip validation step for slurm
         pass
 

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -35,6 +35,7 @@ from torchx.specs.api import (
     Role,
     runopts,
 )
+from torchx.util.types import none_throws
 from torchx.workspace.api import WorkspaceMixin
 
 T = TypeVar("T")
@@ -261,6 +262,14 @@ class SampleOpts(StructuredOpts):
     """Optional tag for the job."""
 
 
+@dataclass
+class KebabOpts(StructuredOpts):
+    """Options with a hyphenated external config key."""
+
+    mail_user: str | None = field(default=None, metadata={"cfg_key": "mail-user"})
+    """User to mail on job end."""
+
+
 class StructuredOptsTest(unittest.TestCase):
     """Tests for StructuredOpts base class functionality."""
 
@@ -303,6 +312,26 @@ class StructuredOptsTest(unittest.TestCase):
         opts = SampleOpts.from_cfg(cfg)
 
         self.assertEqual(opts.cluster_name, "snake_value")
+
+    def test_cfg_key_metadata_alias(self) -> None:
+        """Field metadata ``cfg_key`` maps external keys that cannot be
+        field names (e.g. hyphenated ``mail-user``) across from_cfg,
+        as_runopts, __getitem__, and iteration."""
+        opts = KebabOpts.from_cfg({"mail-user": "foo@bar.com"})
+        self.assertEqual(
+            "foo@bar.com", opts.mail_user, "from_cfg must accept the cfg_key alias"
+        )
+        self.assertEqual(
+            "foo@bar.com", opts["mail-user"], "__getitem__ must accept the cfg_key"
+        )
+        self.assertEqual(["mail-user"], list(opts), "iteration must yield the cfg_key")
+        runopt = KebabOpts.as_runopts().get("mail-user")
+        self.assertIsNotNone(runopt, "as_runopts must register the cfg_key")
+        self.assertEqual(
+            "User to mail on job end.",
+            none_throws(runopt).help,
+            "help text must come from the field docstring",
+        )
 
     # -------------------------------------------------------------------------
     # Mapping Protocol Tests

--- a/torchx/schedulers/test/slurm_scheduler_test.py
+++ b/torchx/schedulers/test/slurm_scheduler_test.py
@@ -118,7 +118,7 @@ class SlurmSchedulerTest(unittest.TestCase):
     def test_replica_request(self, mock_version: MagicMock) -> None:
         role = simple_role()
         sbatch, srun = SlurmReplicaRequest.from_role(
-            "role-0", role, cfg={}, nomem=False
+            "role-0", role, cfg=SlurmOpts(), nomem=False
         ).materialize()
         self.assertEqual(
             sbatch,
@@ -154,7 +154,7 @@ class SlurmSchedulerTest(unittest.TestCase):
         sbatch, srun = SlurmReplicaRequest.from_role(
             "role-name",
             simple_role(),
-            cfg={},
+            cfg=SlurmOpts(),
             nomem=True,
         ).materialize()
         self.assertEqual(
@@ -177,7 +177,7 @@ class SlurmSchedulerTest(unittest.TestCase):
         sbatch, srun = SlurmReplicaRequest.from_role(
             "role-name",
             simple_role(),
-            cfg={"constraint": "orange"},
+            cfg=SlurmOpts(constraint="orange"),
             nomem=False,
         ).materialize()
         self.assertIn(
@@ -193,7 +193,7 @@ class SlurmSchedulerTest(unittest.TestCase):
             args=[f"hello {specs.macros.app_id}"],
         )
         _, srun = SlurmReplicaRequest.from_role(
-            "role-name", role, cfg={}, nomem=False
+            "role-name", role, cfg=SlurmOpts(), nomem=False
         ).materialize()
         self.assertIn(
             "echo 'hello '\"$SLURM_JOB_ID\"''",
@@ -208,12 +208,7 @@ class SlurmSchedulerTest(unittest.TestCase):
             entrypoint="echo",
             args=["hello"],
         )
-        cfg = SlurmOpts(
-            {
-                "partition": "bubblegum",
-                "time": "5:13",
-            }
-        )
+        cfg = SlurmOpts(partition="bubblegum", time="5:13")
 
         sbatch, _ = SlurmReplicaRequest.from_role(
             "role-name", role, cfg, nomem=False
@@ -221,7 +216,7 @@ class SlurmSchedulerTest(unittest.TestCase):
 
         run_opts = scheduler.run_opts()
 
-        for k, v in cfg.items():
+        for k, v in {"partition": "bubblegum", "time": "5:13"}.items():
             self.assertIsNotNone(run_opts.get(k))
             self.assertIn(
                 f"--{k}={v}",
@@ -863,7 +858,7 @@ source sbatch.sh
         sbatch, srun = SlurmReplicaRequest.from_role(
             "role-name",
             simple_role(),
-            cfg={"qos": "high"},
+            cfg=SlurmOpts(qos="high"),
             nomem=False,
         ).materialize()
         self.assertIn(
@@ -947,7 +942,7 @@ source sbatch.sh
             sbatch, srun = SlurmReplicaRequest.from_role(
                 "role-name",
                 role,
-                cfg={},
+                cfg=SlurmOpts(),
                 nomem=False,
             ).materialize()
             self.assertIn("--gpus-per-node=3", sbatch)
@@ -961,7 +956,7 @@ source sbatch.sh
             sbatch, srun = SlurmReplicaRequest.from_role(
                 "role-name",
                 role,
-                cfg={},
+                cfg=SlurmOpts(),
                 nomem=False,
             ).materialize()
             self.assertIn("--gpus-per-task=3", sbatch)
@@ -1010,7 +1005,7 @@ source sbatch.sh
         sbatch, srun = SlurmReplicaRequest.from_role(
             "role-name",
             simple_role(),
-            cfg={"qos": "high", "constraint": "gpu"},
+            cfg=SlurmOpts(qos="high", constraint="gpu"),
             nomem=False,
         ).materialize()
         self.assertIn("--qos=high", sbatch)
@@ -1055,7 +1050,7 @@ source sbatch.sh
             sbatch, srun = SlurmReplicaRequest.from_role(
                 "role-name",
                 role,
-                cfg={},
+                cfg=SlurmOpts(),
                 nomem=False,
             ).materialize()
             self.assertNotIn("--gpus-per-node", " ".join(sbatch))
@@ -1069,7 +1064,7 @@ source sbatch.sh
             sbatch, srun = SlurmReplicaRequest.from_role(
                 "role-name",
                 role,
-                cfg={},
+                cfg=SlurmOpts(),
                 nomem=False,
             ).materialize()
             self.assertNotIn("--gpus-per-node", " ".join(sbatch))

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -70,6 +70,15 @@ def _create_args_parser_from_parameters(
             values: Any,
             option_string: str | None = None,
         ) -> None:
+            if (
+                len(values) == 0
+                and getattr(namespace, self.dest, None) is not self.default
+            ):
+                # REMAINDER actions fire even when no varargs were passed on the
+                # CLI; keep a pre-seeded namespace attr (e.g. the cli_unset
+                # sentinel in parse_args) intact so an empty CLI is not
+                # mistaken for an explicitly passed empty varargs list
+                return
             setattr(
                 namespace,
                 self.dest,
@@ -116,10 +125,12 @@ def _create_args_parser_from_parameters(
 
 
 def _merge_config_values_with_args(
-    parsed_args: argparse.Namespace, config: dict[str, Any]
+    parsed_args: argparse.Namespace, config: dict[str, Any], cli_set_args: set[str]
 ) -> None:
+    """Fills ``parsed_args`` with ``config`` values for the args that were not
+    explicitly passed on the CLI (config overrides defaults, never CLI args)."""
     for key, val in config.items():
-        if key in parsed_args:
+        if key in parsed_args and key not in cli_set_args:
             setattr(parsed_args, key, val)
 
 
@@ -132,6 +143,9 @@ def parse_args(
     """
     Parse passed arguments, defaults, and config values into a namespace for
     a component function.
+
+    Precedence (high -> low): explicitly passed ``cmpnt_args`` > ``config`` >
+    ``cmpnt_defaults`` > defaults declared on the fn signature.
 
     Args:
     cmpnt_fn: Component function
@@ -147,7 +161,20 @@ def parse_args(
     script_parser = _create_args_parser(cmpnt_fn, cmpnt_defaults, config)
     parsed_args = script_parser.parse_args(cmpnt_args)
     if config:
-        _merge_config_values_with_args(parsed_args, config)
+        # re-parse onto a sentinel-seeded namespace: argparse applies defaults
+        # only for attrs missing from the given namespace, so attrs still
+        # holding the sentinel afterwards were NOT explicitly passed on the CLI
+        cli_unset = object()
+        seeded_namespace = Namespace(
+            **dict.fromkeys(inspect.signature(cmpnt_fn).parameters, cli_unset)
+        )
+        script_parser.parse_args(cmpnt_args, namespace=seeded_namespace)
+        cli_set_args = {
+            name
+            for name, value in vars(seeded_namespace).items()
+            if value is not cli_unset
+        }
+        _merge_config_values_with_args(parsed_args, config, cli_set_args)
 
     return parsed_args
 

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -23,6 +23,7 @@ from torchx.specs.builders import (
     DeviceMount,
     make_app_handle,
     materialize_appdef,
+    parse_args,
     parse_mounts,
     VolumeMount,
 )
@@ -53,6 +54,84 @@ def get_dummy_application(role: str) -> AppDef:
 def example_empty_fn() -> AppDef:
     """Empty function that returns dummy app"""
     return get_dummy_application("trainer")
+
+
+def example_fn_for_config(
+    foo: str = "declared_foo", bar: int = 1, baz: str = "declared_baz"
+) -> AppDef:
+    """Dummy app parameterized by foo, bar, baz
+
+    Args:
+        foo: foo param
+        bar: bar param
+        baz: baz param
+    """
+    return get_dummy_application("trainer")
+
+
+class ParseArgsConfigPrecedenceTest(unittest.TestCase):
+    def test_cli_args_beat_config_values(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            ["--foo", "from_cli"],
+            config={"foo": "from_config", "bar": 2},
+        )
+        self.assertEqual(
+            "from_cli", parsed.foo, "explicitly passed CLI arg must win over config"
+        )
+        self.assertEqual(2, parsed.bar, "config must fill args not passed on the CLI")
+        self.assertEqual(
+            "declared_baz",
+            parsed.baz,
+            "declared default must be kept when neither CLI nor config set the arg",
+        )
+
+    def test_config_beats_cmpnt_defaults(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            [],
+            cmpnt_defaults={"foo": "from_cmpnt_defaults"},
+            config={"foo": "from_config"},
+        )
+        self.assertEqual(
+            "from_config", parsed.foo, "config must win over cmpnt_defaults"
+        )
+
+    def test_config_fills_varargs_on_empty_cli(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["cfg1", "cfg2"],
+            parsed.args,
+            "config must fill *args when no varargs were passed on the CLI",
+        )
+
+    def test_cli_varargs_beat_config(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval", "arg1", "arg2"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["arg1", "arg2"],
+            parsed.args,
+            "explicitly passed CLI varargs must win over config",
+        )
+
+    def test_cli_args_beat_config_via_materialize_appdef(self) -> None:
+        app = materialize_appdef(
+            example_fn_with_bool,
+            ["--flag", "True"],
+            config={"flag": False},
+        )
+        self.assertEqual(
+            "trainer-with-flag",
+            app.roles[0].name,
+            "explicitly passed CLI arg must win over config",
+        )
 
 
 def example_fn_with_bool(flag: bool = False) -> AppDef:

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -96,10 +96,6 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
         updates ``role.image`` with the resulting image id.
         """
 
-        old_imgs = [
-            image.id
-            for image in self._docker_client.images.list(name=cfg["image_repo"])
-        ]
         context = _build_context(role.image, workspace)
 
         try:
@@ -136,9 +132,8 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
                     image_id = aux["ID"]
                 if error := event.get("error"):
                     raise BuildError(reason=error, build_log=None)
-            if len(old_imgs) == 0 or role.image not in old_imgs:
-                assert image_id, "image id was not found"
-                role.image = image_id
+            assert image_id, "image id was not found"
+            role.image = image_id
 
         finally:
             context.close()

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -153,6 +153,31 @@ class DockerWorkspaceMockTest(unittest.TestCase):
         self.assertEqual(mock_log.info.call_count, 2)
 
     @patch("torchx.workspace.docker_workspace.log")
+    def test_build_updates_role_image_even_if_current_image_in_repo(
+        self, mock_log: MagicMock
+    ) -> None:
+        client = MagicMock()
+        image_id = "sha256:new_build"
+        client.api.build.return_value = [{"aux": {"ID": image_id}}]
+        # role.image is an image id currently tagged under image_repo — the
+        # scenario where the old `old_imgs` guard silently discarded the build
+        old_image = MagicMock()
+        old_image.id = "sha256:old_build"
+        client.images.list.return_value = [old_image]
+        workspace = DockerWorkspaceMixin(docker_client=client)
+        role = Role(name="b", image="sha256:old_build")
+        workspace.build_workspace_and_update_role(
+            role=role,
+            workspace="bogus",
+            cfg={"image_repo": "example.com/repo", "quiet": "true"},
+        )
+        self.assertEqual(
+            image_id,
+            role.image,
+            "a successful build must always stamp the built image onto the role",
+        )
+
+    @patch("torchx.workspace.docker_workspace.log")
     def test_build_workspace_and_update_raises_error(self, mock_log: MagicMock) -> None:
         client = MagicMock()
         img = MagicMock()


### PR DESCRIPTION
Summary:

`SlurmOpts` was a functional-syntax `TypedDict` (kept only for its hyphenated keys) plus ~55 lines of hand-built `runopts` that duplicated every option name/help, with `pyre-fixme`s on each non-literal key access. This diff migrates it to a `StructuredOpts` dataclass like the other schedulers: `_run_opts()` becomes `SlurmOpts.as_runopts()`, `_submit_dryrun`/`from_role` use typed field access (dropping the `SBATCH_JOB_OPTIONS`/`SBATCH_GROUP_OPTIONS` sets and both `pyre-fixme`s), and the class follows `local_scheduler`'s `Scheduler[Mapping[str, CfgVal]]` shape so dict cfgs keep type-checking.

**Hyphenated keys**: `StructuredOpts` gains minimal field-metadata alias support — `field(metadata={"cfg_key": "mail-user"})` overrides the external key in `as_runopts`/`from_cfg`/`__getitem__`/iteration (new `test_cfg_key_metadata_alias`; existing `test_dryrun_mail` exercises it end-to-end through `submit_dryrun`). Rider: `get_docstrings` regex allows quotes inside field docstrings (needed by the `time` help; previously truncated at the first `"`).

Behavior notes: `--comment/--mail-user/--mail-type/--account` now emit in fixed declaration order (previously Python set-iteration order); a stale-annotation-only change otherwise.

Differential Revision: D116153344
