### PR TITLE
(bugfix)[3/6][torchx][workspace] Always stamp the built image onto the role (#1392)

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import copy
 import json
 import logging
 import os
@@ -341,6 +342,29 @@ class Runner:
         The returned :py:class:`~torchx.specs.AppDryRunInfo` can be
         ``print()``-ed for inspection or passed to :py:meth:`schedule`.
         """
+        # operate on a copy so that the env injection and workspace overwrite
+        # below never leak into the caller's AppDef (one AppDef can be
+        # dry-run multiple times); the copy rides in the returned
+        # AppDryRunInfo's `_app`.
+        #
+        # Role.overrides may already hold non-deepcopyable values (e.g. APF
+        # attaches an in-flight fbpkg Future before calling dryrun), so mirror
+        # the macros.Values.apply pattern: detach overrides, deepcopy, then
+        # attach the SAME dict object to both the original and the copy —
+        # sharing is the intended semantic: resolving an override through
+        # either owner benefits both.
+        detached_overrides = [role.overrides for role in app.roles]
+        for role in app.roles:
+            role.overrides = {}
+        try:
+            app_copy = copy.deepcopy(app)
+        finally:
+            for role, overrides in zip(app.roles, detached_overrides):
+                role.overrides = overrides
+        for role_copy, overrides in zip(app_copy.roles, detached_overrides):
+            role_copy.overrides = overrides
+        app = app_copy
+
         # input validation
         if not app.roles:
             raise ValueError(

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import copy
 import datetime
 import os
 from contextlib import contextmanager
@@ -259,9 +261,10 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            scheduler_mock.submit_dryrun.assert_called_once_with(
-                app, {**self.cfg, "foo": "bar"}
-            )
+            scheduler_mock.submit_dryrun.assert_called_once()
+            submitted_app, resolved_cfg = scheduler_mock.submit_dryrun.call_args[0]
+            self.assertEqual(app.name, submitted_app.name)
+            self.assertEqual({**self.cfg, "foo": "bar"}, resolved_cfg)
             scheduler_mock._validate.assert_called_once()
             from torchx.util.session import CURRENT_SESSION_ID
 
@@ -295,10 +298,15 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg)
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_JOB_ID],
                     "local_dir://" + SESSION_NAME + "/${app_id}",
+                )
+            for role in app.roles:
+                self.assertNotIn(
+                    ENV_TORCHX_JOB_ID, role.env, "caller's AppDef must not be mutated"
                 )
 
     def test_dryrun_trackers_parent_run_id_as_paramenter(self, _: MagicMock) -> None:
@@ -328,7 +336,8 @@ class RunnerTest(TestWithTmpDir):
             runner.dryrun(
                 app, "local_dir", cfg=self.cfg, parent_run_id=expected_parent_run_id
             )
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env[ENV_TORCHX_PARENT_RUN_ID],
                     expected_parent_run_id,
@@ -369,7 +378,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -419,7 +429,8 @@ class RunnerTest(TestWithTmpDir):
             )
             app = AppDef("name", roles=[role1, role2])
             runner.dryrun(app, "local_dir", cfg=self.cfg, parent_run_id="999")
-            for role in app.roles:
+            submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+            for role in submitted_app.roles:
                 self.assertEqual(
                     role.env["TORCHX_TRACKERS"],
                     expected_trackers,
@@ -432,6 +443,78 @@ class RunnerTest(TestWithTmpDir):
                     role.env["TORCHX_TRACKER_MY_TRACKER2_CONFIG"],
                     expected_tracker2_config,
                 )
+
+    def test_dryrun_does_not_mutate_caller_appdef(self, _: MagicMock) -> None:
+        sched1_mock = MagicMock()
+        sched2_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched1": lambda session_name, **kwargs: sched1_mock,
+                "sched2": lambda session_name, **kwargs: sched2_mock,
+            },
+        ) as runner:
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+            )
+            app = AppDef("name", roles=[role])
+            pristine_app = copy.deepcopy(app)
+
+            runner.dryrun(app, "sched1", cfg=self.cfg)
+            runner.dryrun(app, "sched2", cfg=self.cfg)
+
+            self.assertEqual(
+                pristine_app, app, "dryrun must not mutate the caller's AppDef"
+            )
+            # each dryrun's env injection lands on the submitted copy
+            for scheduler, scheduler_mock in [
+                ("sched1", sched1_mock),
+                ("sched2", sched2_mock),
+            ]:
+                submitted_app = scheduler_mock.submit_dryrun.call_args[0][0]
+                self.assertEqual(
+                    f"{scheduler}://{SESSION_NAME}/${{app_id}}",
+                    submitted_app.roles[0].env[ENV_TORCHX_JOB_ID],
+                )
+
+    def test_dryrun_with_non_deepcopyable_overrides(self, _: MagicMock) -> None:
+        """Role.overrides may hold values deepcopy chokes on (e.g. an APF
+        fbpkg Future attached before dryrun); dryrun must succeed and the
+        submitted copy must SHARE the overrides dict with the caller's role
+        so a resolution through either side benefits both."""
+        sched_mock = MagicMock()
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "sched": lambda session_name, **kwargs: sched_mock,
+            },
+        ) as runner:
+            future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            role = Role(
+                name="echo",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="echo",
+                args=["hello world"],
+                overrides={"image": future, "entrypoint": lambda: "echo"},
+            )
+            app = AppDef("name", roles=[role])
+
+            runner.dryrun(app, "sched", cfg=self.cfg)
+
+            submitted_role = sched_mock.submit_dryrun.call_args[0][0].roles[0]
+            self.assertIs(
+                role.overrides,
+                submitted_role.overrides,
+                "the copy must share the caller's overrides dict",
+            )
+            self.assertIsNot(
+                role, submitted_role, "dryrun must still operate on a role copy"
+            )
 
     def test_dryrun_with_workspace(self, _: MagicMock) -> None:
         class TestScheduler(WorkspaceMixin[None], Scheduler):
@@ -572,7 +655,13 @@ class RunnerTest(TestWithTmpDir):
             app = AppDef("sleeper", roles=[role], metadata=metadata)
 
             app_handle = runner.run(app, scheduler="local_dir", cfg=self.cfg)
-            self.assertEqual(app, runner.describe(app_handle))
+            described = none_throws(runner.describe(app_handle))
+            # describe() returns the submitted copy which additionally carries
+            # the runner's env injection (TORCHX_*) and scheduler-side env
+            # tweaks (e.g. local scheduler's PATH prepend); ignore env
+            for role in described.roles:
+                role.env.clear()
+            self.assertEqual(app, described)
             # unknown app should return None
             self.assertIsNone(runner.describe("local_dir://session1/unknown_app"))
 

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -70,6 +70,15 @@ def _create_args_parser_from_parameters(
             values: Any,
             option_string: str | None = None,
         ) -> None:
+            if (
+                len(values) == 0
+                and getattr(namespace, self.dest, None) is not self.default
+            ):
+                # REMAINDER actions fire even when no varargs were passed on the
+                # CLI; keep a pre-seeded namespace attr (e.g. the cli_unset
+                # sentinel in parse_args) intact so an empty CLI is not
+                # mistaken for an explicitly passed empty varargs list
+                return
             setattr(
                 namespace,
                 self.dest,
@@ -116,10 +125,12 @@ def _create_args_parser_from_parameters(
 
 
 def _merge_config_values_with_args(
-    parsed_args: argparse.Namespace, config: dict[str, Any]
+    parsed_args: argparse.Namespace, config: dict[str, Any], cli_set_args: set[str]
 ) -> None:
+    """Fills ``parsed_args`` with ``config`` values for the args that were not
+    explicitly passed on the CLI (config overrides defaults, never CLI args)."""
     for key, val in config.items():
-        if key in parsed_args:
+        if key in parsed_args and key not in cli_set_args:
             setattr(parsed_args, key, val)
 
 
@@ -132,6 +143,9 @@ def parse_args(
     """
     Parse passed arguments, defaults, and config values into a namespace for
     a component function.
+
+    Precedence (high -> low): explicitly passed ``cmpnt_args`` > ``config`` >
+    ``cmpnt_defaults`` > defaults declared on the fn signature.
 
     Args:
     cmpnt_fn: Component function
@@ -147,7 +161,20 @@ def parse_args(
     script_parser = _create_args_parser(cmpnt_fn, cmpnt_defaults, config)
     parsed_args = script_parser.parse_args(cmpnt_args)
     if config:
-        _merge_config_values_with_args(parsed_args, config)
+        # re-parse onto a sentinel-seeded namespace: argparse applies defaults
+        # only for attrs missing from the given namespace, so attrs still
+        # holding the sentinel afterwards were NOT explicitly passed on the CLI
+        cli_unset = object()
+        seeded_namespace = Namespace(
+            **dict.fromkeys(inspect.signature(cmpnt_fn).parameters, cli_unset)
+        )
+        script_parser.parse_args(cmpnt_args, namespace=seeded_namespace)
+        cli_set_args = {
+            name
+            for name, value in vars(seeded_namespace).items()
+            if value is not cli_unset
+        }
+        _merge_config_values_with_args(parsed_args, config, cli_set_args)
 
     return parsed_args
 

--- a/torchx/specs/test/builders_test.py
+++ b/torchx/specs/test/builders_test.py
@@ -23,6 +23,7 @@ from torchx.specs.builders import (
     DeviceMount,
     make_app_handle,
     materialize_appdef,
+    parse_args,
     parse_mounts,
     VolumeMount,
 )
@@ -53,6 +54,84 @@ def get_dummy_application(role: str) -> AppDef:
 def example_empty_fn() -> AppDef:
     """Empty function that returns dummy app"""
     return get_dummy_application("trainer")
+
+
+def example_fn_for_config(
+    foo: str = "declared_foo", bar: int = 1, baz: str = "declared_baz"
+) -> AppDef:
+    """Dummy app parameterized by foo, bar, baz
+
+    Args:
+        foo: foo param
+        bar: bar param
+        baz: baz param
+    """
+    return get_dummy_application("trainer")
+
+
+class ParseArgsConfigPrecedenceTest(unittest.TestCase):
+    def test_cli_args_beat_config_values(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            ["--foo", "from_cli"],
+            config={"foo": "from_config", "bar": 2},
+        )
+        self.assertEqual(
+            "from_cli", parsed.foo, "explicitly passed CLI arg must win over config"
+        )
+        self.assertEqual(2, parsed.bar, "config must fill args not passed on the CLI")
+        self.assertEqual(
+            "declared_baz",
+            parsed.baz,
+            "declared default must be kept when neither CLI nor config set the arg",
+        )
+
+    def test_config_beats_cmpnt_defaults(self) -> None:
+        parsed = parse_args(
+            example_fn_for_config,
+            [],
+            cmpnt_defaults={"foo": "from_cmpnt_defaults"},
+            config={"foo": "from_config"},
+        )
+        self.assertEqual(
+            "from_config", parsed.foo, "config must win over cmpnt_defaults"
+        )
+
+    def test_config_fills_varargs_on_empty_cli(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["cfg1", "cfg2"],
+            parsed.args,
+            "config must fill *args when no varargs were passed on the CLI",
+        )
+
+    def test_cli_varargs_beat_config(self) -> None:
+        parsed = parse_args(
+            example_var_args,
+            ["--foo", "fooval", "arg1", "arg2"],
+            config={"args": ["cfg1", "cfg2"]},
+        )
+        self.assertEqual(
+            ["arg1", "arg2"],
+            parsed.args,
+            "explicitly passed CLI varargs must win over config",
+        )
+
+    def test_cli_args_beat_config_via_materialize_appdef(self) -> None:
+        app = materialize_appdef(
+            example_fn_with_bool,
+            ["--flag", "True"],
+            config={"flag": False},
+        )
+        self.assertEqual(
+            "trainer-with-flag",
+            app.roles[0].name,
+            "explicitly passed CLI arg must win over config",
+        )
 
 
 def example_fn_with_bool(flag: bool = False) -> AppDef:

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -96,10 +96,6 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
         updates ``role.image`` with the resulting image id.
         """
 
-        old_imgs = [
-            image.id
-            for image in self._docker_client.images.list(name=cfg["image_repo"])
-        ]
         context = _build_context(role.image, workspace)
 
         try:
@@ -136,9 +132,8 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
                     image_id = aux["ID"]
                 if error := event.get("error"):
                     raise BuildError(reason=error, build_log=None)
-            if len(old_imgs) == 0 or role.image not in old_imgs:
-                assert image_id, "image id was not found"
-                role.image = image_id
+            assert image_id, "image id was not found"
+            role.image = image_id
 
         finally:
             context.close()

--- a/torchx/workspace/test/docker_workspace_test.py
+++ b/torchx/workspace/test/docker_workspace_test.py
@@ -153,6 +153,31 @@ class DockerWorkspaceMockTest(unittest.TestCase):
         self.assertEqual(mock_log.info.call_count, 2)
 
     @patch("torchx.workspace.docker_workspace.log")
+    def test_build_updates_role_image_even_if_current_image_in_repo(
+        self, mock_log: MagicMock
+    ) -> None:
+        client = MagicMock()
+        image_id = "sha256:new_build"
+        client.api.build.return_value = [{"aux": {"ID": image_id}}]
+        # role.image is an image id currently tagged under image_repo — the
+        # scenario where the old `old_imgs` guard silently discarded the build
+        old_image = MagicMock()
+        old_image.id = "sha256:old_build"
+        client.images.list.return_value = [old_image]
+        workspace = DockerWorkspaceMixin(docker_client=client)
+        role = Role(name="b", image="sha256:old_build")
+        workspace.build_workspace_and_update_role(
+            role=role,
+            workspace="bogus",
+            cfg={"image_repo": "example.com/repo", "quiet": "true"},
+        )
+        self.assertEqual(
+            image_id,
+            role.image,
+            "a successful build must always stamp the built image onto the role",
+        )
+
+    @patch("torchx.workspace.docker_workspace.log")
     def test_build_workspace_and_update_raises_error(self, mock_log: MagicMock) -> None:
         client = MagicMock()
         img = MagicMock()


### PR DESCRIPTION
Summary:

`DockerWorkspaceMixin.build_workspace_and_update_role` skipped the `role.image = image_id` update whenever the pre-build `role.image` was an image ID currently tagged under the local `image_repo` — **silently shipping the stale image without the just-built workspace content**. For normal name-based images the guard compared an image NAME against a list of IDs (always-true no-op); it fired exactly in the one case where it did harm. Worse, with `image_repo` unset, `images.list(name=None)` returns every local image, widening the discard window. This diff fixes this by **unconditionally assigning the built image id after a successful build**.

**Provenance** (why the guard existed): [PR #809](https://github.com/meta-pytorch/torchx/pull/809) / [issue #806](https://github.com/meta-pytorch/torchx/issues/806) added it solely to make the runner's "Built new image / Reusing original image" log truthful. That log has since left `runner/api.py` — it survives only in the fb-only `OrchestratorRunner`, which duplicates its own dryrun — so the guard protected a message that no longer exists on this path.

Reviewed By: athmasagar

Differential Revision: D116153346
