### PR TITLE
(cleanup)[5/5][torchx][hygiene] Convert f-string logging to %s-style; module logger in specs/api (#1393)

### DIFF
--- a/torchx/cli/argparse_util.py
+++ b/torchx/cli/argparse_util.py
@@ -36,7 +36,7 @@ def _check_specified_once(namespace: Namespace, option_string: str | None) -> No
         _called_args_by_namespace[key] = called_args
         weakref.finalize(namespace, _called_args_by_namespace.pop, key)
     if option_string in called_args:
-        logger.error(f"{option_string} is specified more than once")
+        logger.error("`%s` is specified more than once", option_string)
         sys.exit(1)
     called_args.add(option_string)
 

--- a/torchx/cli/cmd_base.py
+++ b/torchx/cli/cmd_base.py
@@ -66,7 +66,8 @@ class AppHandleSubCommand(SubCommand):
         """Logs the shared app-not-found error and exits non-zero."""
         scheduler, _, app_id = parse_app_handle(app_handle)
         logger.error(
-            f"AppDef: {app_id},"
-            f" does not exist or has been removed from {scheduler}'s data plane"
+            "AppDef `%s` does not exist or has been removed from `%s`'s data plane",
+            app_id,
+            scheduler,
         )
         sys.exit(1)

--- a/torchx/cli/cmd_log.py
+++ b/torchx/cli/cmd_log.py
@@ -35,9 +35,7 @@ ID_FORMAT = "SCHEDULER://[SESSION_NAME]/APP_ID/[ROLE_NAME/[REPLICA_IDS,...]]"
 
 def validate(job_identifier: str) -> None:
     if not re.match(r"^\w+://[^/]*/[^/]+(/[^/]+(/(\d+,?)+)?)?$", job_identifier):
-        logger.error(
-            f"{job_identifier} is not of the form {ID_FORMAT}",
-        )
+        logger.error("`%s` is not of the form %s", job_identifier, ID_FORMAT)
         sys.exit(1)
 
 
@@ -136,8 +134,10 @@ def get_logs(
             )
 
             logger.error(
-                f"No role [{role_name}] found for app: {app.name}."
-                f" Did you mean one of the following:\n{valid_ids}",
+                "no role `%s` found for app `%s`, did you mean one of the following:\n%s",
+                role_name,
+                app.name,
+                valid_ids,
             )
             sys.exit(1)
 

--- a/torchx/cli/cmd_run.py
+++ b/torchx/cli/cmd_run.py
@@ -323,7 +323,7 @@ class CmdRun(SubCommand):
                         runner, app_handle, log=True, tee_logs=args.tee_logs
                     )
                 else:
-                    logger.info(f"Launched app: {app_handle}")
+                    logger.info("launched app: `%s`", app_handle)
                     app_status = runner.status(app_handle)
                     if app_status:
                         logger.info(app_status.format())
@@ -464,7 +464,7 @@ class CmdRun(SubCommand):
         if not status:
             raise RuntimeError(f"unknown status, wait returned {status}")
 
-        logger.info(f"Job finished: {status.state}")
+        logger.info("job finished: %s", status.state)
 
         if log_thread:
             log_thread.join()

--- a/torchx/cli/cmd_tracker.py
+++ b/torchx/cli/cmd_tracker.py
@@ -39,7 +39,7 @@ class CmdTracker(SubCommand):
     def tracker(self) -> TrackerBase:
         trackers = list(build_trackers(get_configured_trackers()))
         if trackers:
-            logger.info(f"Using `{trackers[0]}` tracker to query data")
+            logger.info("using `%s` tracker to query data", trackers[0])
             return trackers[0]
         else:
             raise RuntimeError(

--- a/torchx/cli/test/cmd_describe_test.py
+++ b/torchx/cli/test/cmd_describe_test.py
@@ -20,7 +20,7 @@ class CmdDescribeTest(unittest.TestCase):
         resource = Resource(cpu=2, gpu=0, memMB=256)
         trainer = Role(
             name="trainer",
-            image="trainer_fbpkg",
+            image="trainer_image",
             entrypoint="trainer.par",
             args=["--arg1", "foo"],
             resource=resource,

--- a/torchx/components/integration_tests/integ_tests.py
+++ b/torchx/components/integration_tests/integ_tests.py
@@ -67,31 +67,35 @@ class IntegComponentTest:
         runner = get_runner("test-runner")
 
         for app_def in app_defs:
-            log.info(f"Submitting AppDef... (dryrun={dryrun})")
+            log.info("submitting AppDef... (dryrun=%s)", dryrun)
             # get the dryrun info to log the scheduler request
             # then use the schedule (intead of the run API) for job submission
             dryrun_info = runner.dryrun(
                 app_def, scheduler, cfg=cfg, workspace=workspace
             )
-            log.info(f"\nAppDef:\n{dumps(asdict(app_def), indent=4)}")
-            log.info(f"\nScheduler Request:\n{dryrun_info}")
+            log.info("\nAppDef:\n%s", dumps(asdict(app_def), indent=4))
+            log.info("\nScheduler Request:\n%s", dryrun_info)
 
             if not dryrun:
                 app_handle = runner.schedule(dryrun_info)
                 status = runner.status(app_handle)
                 jobs[app_handle] = none_throws(status)
-                log.info(f"Submitted Application ({app_handle})")
+                log.info("submitted application `%s`", app_handle)
             else:
                 log.info(
-                    f"Dryrun, not submitting application to scheduler=`{scheduler}`"
+                    "dryrun, not submitting application to scheduler `%s`", scheduler
                 )
 
         # batch wait for the states
         for app_handle, status in jobs.items():
-            log.info(f"Waiting for {app_handle} to finish...")
+            log.info("waiting for `%s` to finish...", app_handle)
             status = none_throws(runner.wait(app_handle))
             log.info(
-                f"App ({app_handle}) finished with state=`{status.state}` and msg=`{status.msg}` (see application log lines below)"
+                "app `%s` finished with state=`%s` and msg=`%s`"
+                " (see application log lines below)",
+                app_handle,
+                status.state,
+                status.msg,
             )
             jobs[app_handle] = status
 
@@ -108,7 +112,7 @@ class IntegComponentTest:
             handles = group_by_state.setdefault(status.state, [])
             handles.append(app_handle)
 
-        log.info(f"\n{'*'*40}{dumps(group_by_state, indent=4)}\n{'*' * 40}")
+        log.info("\n%s%s\n%s", "*" * 40, dumps(group_by_state, indent=4), "*" * 40)
 
         # assert that all jobs have been successful (jobs not in final state SUCCEEDED are considered a failure)
         num_total = len(jobs)

--- a/torchx/deprecations.py
+++ b/torchx/deprecations.py
@@ -14,9 +14,6 @@ paths and :func:`deprecated` for marking functions/classes as deprecated.
 Both emit :py:class:`UserWarning` (not ``DeprecationWarning``) so that
 warnings are always visible to end users — ``DeprecationWarning`` is
 silenced by default outside ``__main__``.
-
-For Meta-internal use (fbsource-specific path resolution and sed commands),
-see :py:mod:`torchx.fb.deprecations` which layers on top of this module.
 """
 
 from __future__ import annotations

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -66,8 +66,10 @@ T = TypeVar("T")
 def get_configured_trackers() -> dict[str, str | None]:
     tracker_names = list(get_configs(prefix="torchx", name="tracker").keys())
     if settings.ENV_TORCHX_TRACKERS in os.environ:
-        logger.info(f"Using TORCHX_TRACKERS={tracker_names} as tracker names")
         tracker_names = os.environ[settings.ENV_TORCHX_TRACKERS].split(",")
+        logger.info(
+            "using %s=%s as tracker names", settings.ENV_TORCHX_TRACKERS, tracker_names
+        )
 
     tracker_names_with_config = {}
     for tracker_name in tracker_names:
@@ -77,11 +79,14 @@ def get_configured_trackers() -> dict[str, str | None]:
         if config_env_name in os.environ:
             config_value = os.environ[config_env_name]
             logger.info(
-                f"Using {config_env_name}={config_value} for `{tracker_name}` tracker"
+                "using %s=%s for `%s` tracker",
+                config_env_name,
+                config_value,
+                tracker_name,
             )
 
         tracker_names_with_config[tracker_name] = config_value
-    logger.info(f"Tracker configurations: {tracker_names_with_config}")
+    logger.info("tracker configurations: %s", tracker_names_with_config)
     return tracker_names_with_config
 
 
@@ -374,7 +379,9 @@ class Runner:
         if settings.ENV_TORCHX_PARENT_RUN_ID in os.environ:
             parent_run_id = os.environ[settings.ENV_TORCHX_PARENT_RUN_ID]
             logger.info(
-                f"Using {settings.ENV_TORCHX_PARENT_RUN_ID}={parent_run_id} env variable as tracker parent run id"
+                "using %s=%s env variable as tracker parent run id",
+                settings.ENV_TORCHX_PARENT_RUN_ID,
+                parent_run_id,
             )
 
         configured_trackers = get_configured_trackers()

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -46,7 +46,7 @@ from torchx.specs import (
 )
 from torchx.specs.finder import get_component
 from torchx.tracker.api import tracker_config_env_var_name
-from torchx.util.session import get_session_id_or_create_new, TORCHX_INTERNAL_SESSION_ID
+from torchx.util.session import get_session_id_or_create_new
 from torchx.util.types import none_throws
 from torchx.workspace import WorkspaceMixin
 
@@ -400,7 +400,9 @@ class Runner:
             role.env[settings.ENV_TORCHX_JOB_ID] = make_app_handle(
                 scheduler, self._name, macros.app_id
             )
-            role.env[TORCHX_INTERNAL_SESSION_ID] = get_session_id_or_create_new()
+            role.env[settings.ENV_TORCHX_INTERNAL_SESSION_ID] = (
+                get_session_id_or_create_new()
+            )
 
             if parent_run_id:
                 role.env[settings.ENV_TORCHX_PARENT_RUN_ID] = parent_run_id

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -472,11 +472,10 @@ class Runner:
 
         .. doctest::
 
-            from torchx.runner import get_runner
-
-            runner = get_runner()
-            cfg = runner.cfg_from_str("local_cwd", "log_dir=/tmp/foobar", "prepend_cwd=True")
-            assert cfg == {"log_dir": "/tmp/foobar", "prepend_cwd": True, "auto_set_cuda_visible_devices": False}
+            >>> from torchx.runner import get_runner
+            >>> runner = get_runner()
+            >>> runner.cfg_from_str("local_cwd", "log_dir=/tmp/foobar", "prepend_cwd=True")
+            {'log_dir': '/tmp/foobar', 'prepend_cwd': True}
         """
 
         opts = self._scheduler(scheduler).run_opts()

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -137,7 +137,7 @@ You'll have to manually specify the directory containing ``.torchxconfig``.
 
 Below is an example
 
-.. doctest:: [runner_config_example]
+::
 
  from torchx.runner import get_runner
  from torchx.runner.config import apply

--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -337,7 +337,7 @@ def apply(
     for configfile in find_configs(dirs):
         with open(configfile, "r") as f:
             load(scheduler, f, cfg)
-            log.info(f"loaded configs from {configfile}")
+            log.info("loaded configs from `%s`", configfile)
 
 
 def load_sections(
@@ -418,7 +418,11 @@ def load_sections(
                 for key, value in config.items(section_name):
                     if key not in section:
                         log.debug(
-                            f"Loaded config: {prefix}.{key}={value} from {configfile}"
+                            "loaded config: %s.%s=%s from `%s`",
+                            prefix,
+                            key,
+                            value,
+                            configfile,
                         )
                         section[key] = value
 
@@ -542,9 +546,13 @@ def load(scheduler: str, f: TextIO, cfg: dict[str, CfgVal]) -> None:
 
                 if opt is None:
                     log.warning(
-                        f"`{name} = {value}` was declared in the [{section}] section "
-                        f" of the config file but is not a runopt of `{scheduler}` scheduler."
-                        f" Remove the entry from the config file to no longer see this warning"
+                        "`%s = %s` was declared in the [%s] section"
+                        " of the config file but is not a runopt of `%s` scheduler,"
+                        " remove the entry from the config file to no longer see this warning",
+                        name,
+                        value,
+                        section,
+                        scheduler,
                     )
                 else:
                     # delegate casting to the runopt itself so configfile

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -348,13 +348,13 @@ class RunnerTest(TestWithTmpDir):
         self, config_trackers_mock: MagicMock, _: MagicMock
     ) -> None:
         config_trackers_mock.return_value = {
-            "my_tracker1": "manifold://config1.txt",
-            "my_tracker2": "manifold://config2.txt",
+            "my_tracker1": "s3://config1.txt",
+            "my_tracker2": "s3://config2.txt",
         }
         scheduler_mock = MagicMock()
         expected_trackers = "my_tracker1,my_tracker2"
-        expected_tracker1_config = "manifold://config1.txt"
-        expected_tracker2_config = "manifold://config2.txt"
+        expected_tracker1_config = "s3://config1.txt"
+        expected_tracker2_config = "s3://config2.txt"
 
         with Runner(
             name=SESSION_NAME,
@@ -397,15 +397,15 @@ class RunnerTest(TestWithTmpDir):
         os.environ,
         {
             "TORCHX_TRACKERS": "my_tracker1,my_tracker2",
-            "TORCHX_TRACKER_MY_TRACKER1_CONFIG": "manifold://config1.txt",
-            "TORCHX_TRACKER_MY_TRACKER2_CONFIG": "manifold://config2.txt",
+            "TORCHX_TRACKER_MY_TRACKER1_CONFIG": "s3://config1.txt",
+            "TORCHX_TRACKER_MY_TRACKER2_CONFIG": "s3://config2.txt",
         },
     )
     def test_dryrun_setup_trackers_as_env_variable(self, _: MagicMock) -> None:
         scheduler_mock = MagicMock()
         expected_trackers = "my_tracker1,my_tracker2"
-        expected_tracker1_config = "manifold://config1.txt"
-        expected_tracker2_config = "manifold://config2.txt"
+        expected_tracker1_config = "s3://config1.txt"
+        expected_tracker2_config = "s3://config2.txt"
 
         with Runner(
             name=SESSION_NAME,

--- a/torchx/runner/test/resource/distributed.py
+++ b/torchx/runner/test/resource/distributed.py
@@ -34,6 +34,6 @@ def ddp(
         resource=specs.Resource(cpu=1, gpu=0, memMB=1),
     )
 
-    # get app name from cli or extract from fbpkg. Note that fbpkg name can has "."
-    # but not allowed in app name.
+    # get app name from cli or derive it from the image. Note that image names
+    # may contain "." which is not allowed in app names.
     return specs.AppDef(name, roles=[ddp_role])

--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -199,11 +199,13 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
         for image in images:
             if image.startswith("sha256:"):
                 continue
-            log.info(f"Pulling container image: {image} (this may take a while)")
+            log.info("pulling container image: `%s` (this may take a while)", image)
             try:
                 client.images.pull(image)
             except Exception as e:
-                log.warning(f"failed to pull image {image}, falling back to local: {e}")
+                log.warning(
+                    "failed to pull image `%s`, falling back to local: %s", image, e
+                )
 
         ensure_network(self._docker_client)
 

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -329,7 +329,7 @@ class _LocalReplica:
         try:
             os.killpg(self.proc.pid, signal.SIGTERM)
         except ProcessLookupError as e:
-            log.debug(f"Process {self.proc.pid} already got terminated")
+            log.debug("process %s already got terminated", self.proc.pid)
 
         # close stdout and stderr log file handles
         if self.stdout:
@@ -482,7 +482,7 @@ class _LocalAppDef:
         with open(os.path.join(self.log_dir, "SUCCESS"), "w") as fp:
             fp.write(info_str)
 
-        log.debug(f"Successfully closed app_id: {self.id}.\n{info_str}")
+        log.debug("successfully closed app_id `%s`\n%s", self.id, info_str)
 
     def __repr__(self) -> str:
         role_to_pid = {}
@@ -654,10 +654,10 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
             # evict LRU finished app from the apps cache
             del self._apps[lru_app_id]
 
-            log.debug(f"evicting app: {lru_app_id}, from local scheduler cache")
+            log.debug("evicting app `%s` from local scheduler cache", lru_app_id)
             return True
         else:
-            log.debug(f"no apps evicted, all {len(self._apps)} apps are running")
+            log.debug("no apps evicted, all %s apps are running", len(self._apps))
             return False
 
     def _get_file_io(self, file: str | None) -> io.FileIO | None:
@@ -693,7 +693,7 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
         stdout_, stderr_, combined_ = self._get_replica_output_handles(replica_params)
 
         args_pfmt = pprint.pformat(asdict(replica_params), indent=2, width=80)
-        log.debug(f"Running {role_name} (replica {replica_id}):\n {args_pfmt}")
+        log.debug("running `%s` (replica %s):\n %s", role_name, replica_id, args_pfmt)
         env = self._get_replica_env(replica_params)
 
         proc = self.run_local_job(
@@ -789,7 +789,7 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
                 " To preserve log directory set the `log_dir` cfg option"
             )
 
-        log.info(f"Log directory is: {base_log_dir}")
+        log.info("log directory is: `%s`", base_log_dir)
         return os.path.join(str(base_log_dir), self.session_name, app_id)
 
     def schedule(self, dryrun_info: AppDryRunInfo[PopenRequest]) -> str:
@@ -841,18 +841,18 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
         # on //caffe2:torch which slows down builds of //torchx:* rules
         gpu_cmd = "nvidia-smi -L"
         try:
-            log.debug(f"Running {gpu_cmd}")
+            log.debug("running `%s`", gpu_cmd)
             result = subprocess.run(
                 gpu_cmd.split(), capture_output=True, text=True, check=True
             )
-            log.debug(f"Cmd {gpu_cmd} returned: {result}")
+            log.debug("cmd `%s` returned: %s", gpu_cmd, result)
             gpus_info = [gpu_info for gpu_info in result.stdout.split("\n") if gpu_info]
             return len(gpus_info)
         except subprocess.CalledProcessError as e:
-            log.exception(f"Got exception while listing GPUs: {e.stderr}")
+            log.exception("got exception while listing GPUs: %s", e.stderr)
             return 0
         except FileNotFoundError:
-            log.warning(f"`{gpu_cmd}` not found, assuming no GPUs on this host")
+            log.warning("`%s` not found, assuming no GPUs on this host", gpu_cmd)
             return 0
 
     def auto_set_CUDA_VISIBLE_DEVICES(
@@ -921,15 +921,17 @@ set the `auto_set_cuda_visible_devices = True` scheduler runopt
         device_count = self._cuda_device_count()
         if total_requested_gpus > device_count:
             log.warning(
-                f"""\n
+                """\n
 ======================================================================
 Cannot auto-set `CUDA_VISIBLE_DEVICES`
-Available GPUs: {device_count} is less than the
-number of requested GPUs: {total_requested_gpus}."
+Available GPUs: %s is less than the
+number of requested GPUs: %s
 
 Reduce requested GPU resources or use a host with more GPUs
 ======================================================================
-                """
+                """,
+                device_count,
+                total_requested_gpus,
             )
             return
 
@@ -1118,7 +1120,7 @@ Reduce requested GPU resources or use a host with more GPUs
     def close(self) -> None:
         # terminate all apps
         for app_id, app in self._apps.items():
-            log.debug(f"Terminating app: {app_id}")
+            log.debug("terminating app `%s`", app_id)
             app.kill()
         # delete only the log dirs torchx created, never a user-provided log_dir
         for tmp_log_dir in self._tmp_log_dirs:
@@ -1132,7 +1134,9 @@ Reduce requested GPU resources or use a host with more GPUs
             # When the `__del__` method is invoked, we cannot rely on presence of object attributes,
             # More info: https://stackoverflow.com/questions/18058730/python-attributeerror-on-del
             log.warning(
-                f"Exception {e} occurred while trying to clean `LocalScheduler` via `__del__` method"
+                "exception %s occurred while trying to clean `LocalScheduler`"
+                " via `__del__` method",
+                e,
             )
 
 

--- a/torchx/schedulers/slurm_scheduler.py
+++ b/torchx/schedulers/slurm_scheduler.py
@@ -550,7 +550,9 @@ class SlurmScheduler(DirWorkspaceMixin, Scheduler[Mapping[str, CfgVal]]):
                 return desc
         except CalledProcessError as e:
             log.info(
-                f"unable to get job info for `{app_id}` with `squeue` ({e.stderr}), trying `sacct`"
+                "unable to get job info for `%s` with `squeue` (%s), trying `sacct`",
+                app_id,
+                e.stderr,
             )
         return self._describe_sacct(app_id)
 

--- a/torchx/settings.py
+++ b/torchx/settings.py
@@ -27,7 +27,7 @@ ENV_TORCHX_JOB_ID: str = "TORCHX_JOB_ID"
 ENV_TORCHXCONFIG: str = "TORCHXCONFIG"
 
 # -- session env vars (previously in torchx.util.session) --
-TORCHX_INTERNAL_SESSION_ID: str = "TORCHX_INTERNAL_SESSION_ID"
+ENV_TORCHX_INTERNAL_SESSION_ID: str = "TORCHX_INTERNAL_SESSION_ID"
 
 # -- image env vars (previously in torchx.schedulers.docker_scheduler) --
 ENV_TORCHX_IMAGE: str = "TORCHX_IMAGE"

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1288,7 +1288,11 @@ class runopts:
                 cfg[key] = opt.cast_to_type(val)
             else:
                 logger.warning(
-                    f"{YELLOW_BOLD}Unknown run option passed to scheduler: {key}={val}{RESET}"
+                    "%sunknown run option passed to scheduler: %s=%s%s",
+                    YELLOW_BOLD,
+                    key,
+                    val,
+                    RESET,
                 )
         return cfg
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -80,11 +80,13 @@ def TORCHX_HOME(*subdir_paths: str) -> pathlib.Path:
 
         >>> from torchx.specs import TORCHX_HOME
         >>> import os, pathlib
-        >>> _ = os.environ.pop("TORCHX_HOME", None)  # ensure default
+        >>> _prev = os.environ.pop("TORCHX_HOME", None)  # ensure default
         >>> TORCHX_HOME() == pathlib.Path.home() / ".torchx"
         True
         >>> TORCHX_HOME("conda-pack-out") == pathlib.Path.home() / ".torchx" / "conda-pack-out"
         True
+        >>> if _prev is not None:
+        ...     os.environ["TORCHX_HOME"] = _prev  # restore caller's env
 
     """
 
@@ -1245,26 +1247,37 @@ class runopts:
 
         .. doctest::
 
-         opts = runopts()
-         opts.add("FOO", type_=List[str], default=["a"], help="an optional list option")
-         opts.add("BAR", type_=str, required=True, help="a required str option")
+            >>> from torchx.specs.api import runopts
+            >>> opts = runopts()
+            >>> opts.add("FOO", type_=list[str], default=["a"], help="an optional list option")
+            >>> opts.add("BAR", type_=str, required=True, help="a required str option")
 
-         # required and default options not checked
-         # method returns strictly parsed cfg from the cfg literal string
-         opts.cfg_from_str("") == {}
+            required and default options are not checked; the method returns the
+            strictly parsed cfg from the cfg literal string:
 
-         # however, unknown options are ignored
-         # since the value type is unknown hence cannot cast to the correct type
-         opts.cfg_from_str("UNKNOWN=VALUE") == {}
+            >>> opts.cfg_from_str("")
+            {}
 
-         opts.cfg_from_str("FOO=v1") == {"FOO": "v1"}
+            unknown options are ignored since the value type is unknown
+            hence cannot be cast to the correct type:
 
-         opts.cfg_from_str("FOO=v1,v2") == {"FOO": ["v1", "v2"]}
-         opts.cfg_from_str("FOO=v1;v2") == {"FOO": ["v1", "v2"]}
+            >>> opts.cfg_from_str("UNKNOWN=VALUE")
+            {}
 
-         opts.cfg_from_str("FOO=v1,v2,BAR=v3") == {"FOO": ["v1", "v2"], "BAR": "v3"}
-         opts.cfg_from_str("FOO=v1;v2,BAR=v3") == {"FOO": ["v1", "v2"], "BAR": "v3"}
-         opts.cfg_from_str("FOO=v1;v2;BAR=v3") == {"FOO": ["v1", "v2"], "BAR": "v3"}
+            >>> opts.cfg_from_str("FOO=v1")
+            {'FOO': ['v1']}
+
+            >>> opts.cfg_from_str("FOO=v1,v2")
+            {'FOO': ['v1', 'v2']}
+            >>> opts.cfg_from_str("FOO=v1;v2")
+            {'FOO': ['v1', 'v2']}
+
+            >>> opts.cfg_from_str("FOO=v1,v2,BAR=v3")
+            {'FOO': ['v1', 'v2'], 'BAR': 'v3'}
+            >>> opts.cfg_from_str("FOO=v1;v2,BAR=v3")
+            {'FOO': ['v1', 'v2'], 'BAR': 'v3'}
+            >>> opts.cfg_from_str("FOO=v1;v2;BAR=v3")
+            {'FOO': ['v1', 'v2'], 'BAR': 'v3'}
 
         """
 

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -586,7 +586,7 @@ class Role:
 
     Args:
         name: name of the role
-        image: software bundle installed on the container (docker image, fbpkg, tar-ball, etc.)
+        image: software bundle installed on the container (e.g. docker image, tar-ball)
         entrypoint: command to invoke inside the container
         args: arguments to the entrypoint
         env: environment variable mappings

--- a/torchx/specs/builders.py
+++ b/torchx/specs/builders.py
@@ -207,28 +207,27 @@ def component_args_from_str(
         Usage:
 
         .. doctest::
-            from torchx.specs.api import AppDef
-            from torchx.specs.builders import component_args_from_str
 
-            def example_component_fn(foo: str, *args: str, bar: str = "asdf") -> AppDef:
-                return AppDef(name="example")
+            >>> from torchx.specs.api import AppDef
+            >>> from torchx.specs.builders import component_args_from_str
+            >>> def example_component_fn(foo: str, *args: str, bar: str = "asdf") -> AppDef:
+            ...     return AppDef(name="example")
 
-            # Supports space separated arguments
-            args = ["--foo", "fooval", "--bar", "barval", "arg1", "arg2"]
-            parsed_args = component_args_from_str(example_component_fn, args)
+            supports space separated arguments:
 
-            assert parsed_args.positional_args == {"foo": "fooval"}
-            assert parsed_args.var_args == ["arg1", "arg2"]
-            assert parsed_args.kwargs == {"bar": "barval"}
+            >>> component_args_from_str(
+            ...     example_component_fn,
+            ...     ["--foo", "fooval", "--bar", "barval", "arg1", "arg2"],
+            ... )
+            ComponentArgs(positional_args={'foo': 'fooval'}, var_args=['arg1', 'arg2'], kwargs={'bar': 'barval'})
 
-            # Supports '=' separated arguments
-            args = ["--foo=fooval", "--bar=barval", "arg1", "arg2"]
-            parsed_args = component_args_from_str(example_component_fn, args)
+            and ``=`` separated arguments:
 
-            assert parsed_args.positional_args == {"foo": "fooval"}
-            assert parsed_args.var_args == ["arg1", "arg2"]
-            assert parsed_args.kwargs == {"bar": "barval"}
-
+            >>> component_args_from_str(
+            ...     example_component_fn,
+            ...     ["--foo=fooval", "--bar=barval", "arg1", "arg2"],
+            ... )
+            ComponentArgs(positional_args={'foo': 'fooval'}, var_args=['arg1', 'arg2'], kwargs={'bar': 'barval'})
 
     """
     parsed_args: Namespace = parse_args(

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -956,17 +956,17 @@ class RoleBuilderTest(unittest.TestCase):
             return value
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            launcher_fbpkg_future: concurrent.futures.Future = executor.submit(
+            launcher_image_future: concurrent.futures.Future = executor.submit(
                 delay, ("value1", "value2"), 2
             )
 
         def get_image() -> str:
-            concurrent.futures.wait([launcher_fbpkg_future], 3)
-            return launcher_fbpkg_future.result()[0]
+            concurrent.futures.wait([launcher_image_future], 3)
+            return launcher_image_future.result()[0]
 
         def get_entrypoint() -> str:
-            concurrent.futures.wait([launcher_fbpkg_future], 3)
-            return launcher_fbpkg_future.result()[1]
+            concurrent.futures.wait([launcher_image_future], 3)
+            return launcher_image_future.result()[1]
 
         default = Role(
             "foobar",

--- a/torchx/test/settings_test.py
+++ b/torchx/test/settings_test.py
@@ -24,7 +24,7 @@ class SettingsValueTest(unittest.TestCase):
 
     def test_session_env_var(self) -> None:
         self.assertEqual(
-            settings.TORCHX_INTERNAL_SESSION_ID, "TORCHX_INTERNAL_SESSION_ID"
+            settings.ENV_TORCHX_INTERNAL_SESSION_ID, "TORCHX_INTERNAL_SESSION_ID"
         )
 
     def test_scheduler_env_vars(self) -> None:
@@ -43,6 +43,6 @@ class SettingsBCReexportTest(unittest.TestCase):
 
         self.assertIs(
             session.TORCHX_INTERNAL_SESSION_ID,
-            settings.TORCHX_INTERNAL_SESSION_ID,
+            settings.ENV_TORCHX_INTERNAL_SESSION_ID,
             "session re-export should be the same object",
         )

--- a/torchx/tracker/api.py
+++ b/torchx/tracker/api.py
@@ -129,7 +129,7 @@ def _extract_tracker_name_and_config_from_environ() -> Mapping[str, str | None]:
 
     tracker_backend_entrypoints = os.environ[settings.ENV_TORCHX_TRACKERS]
     logger.info(
-        f"Trackers: {settings.ENV_TORCHX_TRACKERS}={tracker_backend_entrypoints}"
+        "trackers: %s=%s", settings.ENV_TORCHX_TRACKERS, tracker_backend_entrypoints
     )
 
     entries = {}
@@ -157,13 +157,15 @@ def build_trackers(
         factory = plugin if plugin else load_module(factory_name)
         if not factory or not callable(factory):
             logger.warning(
-                f"no tracker factory `{factory_name}` found in plugins or modules. See https://meta-pytorch.org/torchx/main/tracker.html#module-torchx.tracker"
+                "no tracker factory `%s` found in plugins or modules, see"
+                " https://meta-pytorch.org/torchx/main/tracker.html#module-torchx.tracker",
+                factory_name,
             )
             continue
         if config:
-            logger.info(f"Tracker config found for `{factory_name}` as `{config}`")
+            logger.info("tracker config found for `%s` as `%s`", factory_name, config)
         else:
-            logger.info(f"No tracker config specified for `{factory_name}`")
+            logger.info("no tracker config specified for `%s`", factory_name)
         tracker = factory(config)
         trackers.append(tracker)
     # pyrefly: ignore [bad-return]
@@ -230,7 +232,7 @@ class AppRun:
         trackers = trackers_from_environ()
         if settings.ENV_TORCHX_PARENT_RUN_ID in os.environ:
             parent_run_id = os.environ[settings.ENV_TORCHX_PARENT_RUN_ID]
-            logger.info(f"Tracker parent run ID: '{parent_run_id}'")
+            logger.info("tracker parent run ID: `%s`", parent_run_id)
             for tracker in trackers:
                 tracker.add_source(torchx_job_id, parent_run_id, artifact_name=None)
 

--- a/torchx/tracker/backend/test/fsspec_test.py
+++ b/torchx/tracker/backend/test/fsspec_test.py
@@ -48,7 +48,7 @@ class FsspecTest(unittest.TestCase):
         self.assertIsNotNone(filename)
 
     def test_encode_decode_torchx_run(self) -> None:
-        expected_run_id = "mast://session_id/app_id"
+        expected_run_id = "kubernetes://session_id/app_id"
 
         self.assertEqual(
             _decode_torchx_run_id(_encode_torchx_run_id(expected_run_id)),

--- a/torchx/util/session.py
+++ b/torchx/util/session.py
@@ -12,8 +12,8 @@ import uuid
 
 from torchx import settings
 
-# BC re-export — new code should import from torchx.settings
-TORCHX_INTERNAL_SESSION_ID: str = settings.TORCHX_INTERNAL_SESSION_ID
+# Deprecated BC alias — new code should use ``settings.ENV_TORCHX_INTERNAL_SESSION_ID``.
+TORCHX_INTERNAL_SESSION_ID: str = settings.ENV_TORCHX_INTERNAL_SESSION_ID
 
 CURRENT_SESSION_ID: str | None = None
 
@@ -27,7 +27,7 @@ def get_session_id_or_create_new() -> str:
     global CURRENT_SESSION_ID
     if CURRENT_SESSION_ID:
         return CURRENT_SESSION_ID
-    env_session_id = os.getenv(TORCHX_INTERNAL_SESSION_ID)
+    env_session_id = os.getenv(settings.ENV_TORCHX_INTERNAL_SESSION_ID)
     if env_session_id:
         CURRENT_SESSION_ID = env_session_id
         return CURRENT_SESSION_ID

--- a/torchx/workspace/docker_workspace.py
+++ b/torchx/workspace/docker_workspace.py
@@ -103,7 +103,9 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
                 self._docker_client.images.pull(role.image)
             except Exception as e:
                 log.warning(
-                    f"failed to pull image {role.image}, falling back to local: {e}"
+                    "failed to pull image `%s`, falling back to local: %s",
+                    role.image,
+                    e,
                 )
             log.info("Building workspace docker image (this may take a while)...")
             build_events = self._docker_client.api.build(
@@ -176,7 +178,7 @@ class DockerWorkspaceMixin(WorkspaceMixin[dict[str, tuple[str, str]]]):
 
         client = self._docker_client
         for local, (repo, tag) in images_to_push.items():
-            log.info(f"pushing image {repo}:{tag}...")
+            log.info("pushing image `%s:%s`...", repo, tag)
             img = client.images.get(local)
             img.tag(repo, tag=tag)
             print_push_events(
@@ -245,7 +247,7 @@ def _build_context(img: str, workspace: str) -> IO[bytes]:
 
 def _copy_to_tarfile(workspace: str, tf: tarfile.TarFile) -> None:
     fs, path = fsspec.core.url_to_fs(workspace)
-    log.info(f"Workspace `{workspace}` resolved to filesystem path `{path}`")
+    log.info("workspace `%s` resolved to filesystem path `%s`", workspace, path)
     assert isinstance(path, str), "path must be str"
 
     for dir, dirs, files in walk_workspace(fs, path, ".dockerignore"):


### PR DESCRIPTION
Summary:

Converts every remaining f-string logging call in non-fb torchx to `%s`-style. For example, in `cli/cmd_log.py`:

**Before**
```python
logger.error(f"{job_identifier} is not of the form {ID_FORMAT}")
```

**After**
```python
logger.error("`%s` is not of the form %s", job_identifier, ID_FORMAT)
```

With `%s`-style the message is only built when the log level is on (an f-string is always built, even when the line is filtered out), and it matches the torchx logging convention (lowercase, no trailing period, backticked variable names).

Also gives `specs/api.py` a real module logger. It was doing `import logging as logger`, so its two `logger.warning(...)` calls went to the root logger with no module name. Now:

```python
logger: logging.Logger = logging.getLogger(__name__)
```

NOTE: also fixes a wrong log line in `runner/api.py::get_configured_trackers` — it printed the config-derived tracker names while claiming they came from `TORCHX_TRACKERS` (the env read happened one line later). The log now runs after the env override and prints the value actually used.

Differential Revision: D116158217
