### PR TITLE
(bugfix)[torchx][plugins] Equal-value same-name plugin re-registration is idempotent (#1397)

### DIFF
--- a/torchx/plugins/_registry.py
+++ b/torchx/plugins/_registry.py
@@ -127,6 +127,126 @@ class PluginRegistry:
         """
         return f"torchx_plugins.{pt.value.removeprefix('torchx.')}"
 
+    @staticmethod
+    def _normalize_value(v: Any) -> Any:
+        """Structural normalization for cross-distribution value comparison.
+
+        Two portions of the namespace may carry twin GENERATED types (thrift
+        enums/structs regenerated per distribution) whose ``__eq__`` is
+        class-identity-based — semantically identical values compare unequal.
+        Normalize: enums (stdlib Enum AND thrift-python int-subclass enums) by
+        (type name, value), dataclasses and field-iterable structs field-wise,
+        containers recursively, everything else by ``repr``.
+        """
+        if isinstance(v, enum.Enum):
+            return ("enum", type(v).__name__, v.value)
+        if v is None or type(v) in (str, int, float, bool, bytes):
+            return v
+        if isinstance(v, int) and not isinstance(v, bool):
+            # int SUBCLASS: thrift-python enums are int-derived, not enum.Enum
+            return ("enum", type(v).__name__, int(v))
+        if dataclasses.is_dataclass(v) and not isinstance(v, type):
+            return (
+                type(v).__name__,
+                tuple(
+                    (f.name, PluginRegistry._normalize_value(getattr(v, f.name)))
+                    for f in dataclasses.fields(v)
+                ),
+            )
+        if isinstance(v, dict):
+            return tuple(
+                sorted(
+                    (
+                        repr(PluginRegistry._normalize_value(k)),
+                        PluginRegistry._normalize_value(val),
+                    )
+                    for k, val in v.items()
+                )
+            )
+        if isinstance(v, (set, frozenset)):
+            # unordered: equal sets can iterate in different orders (insertion
+            # history), so sort the normalized elements — by repr, like the
+            # dict branch, since they may be heterogeneous/unorderable
+            return tuple(
+                sorted((PluginRegistry._normalize_value(x) for x in v), key=repr)
+            )
+        if isinstance(v, (list, tuple)):
+            return tuple(PluginRegistry._normalize_value(x) for x in v)
+        try:
+            # thrift-python structs iterate as (field_name, value) pairs —
+            # normalize them the same shape as dataclasses
+            pairs = list(v)
+            if pairs and all(
+                isinstance(p, tuple) and len(p) == 2 and isinstance(p[0], str)
+                for p in pairs
+            ):
+                return (
+                    type(v).__name__,
+                    tuple((n, PluginRegistry._normalize_value(x)) for n, x in pairs),
+                )
+        except TypeError:
+            pass
+        return repr(v)
+
+    @staticmethod
+    def _canonical_resource(r: Any) -> Any:
+        """Canonical comparison form of a resource-like value.
+
+        ``Resource.is_fractional()`` treats an ABSENT ``is_fractional`` tag as
+        ``False``, so an explicit ``False`` tag is dropped before comparing —
+        stamping deltas between distributions are not semantic drift.
+        """
+        from torchx.plugins._registration import resource_tags
+
+        tags = dict(r.tags)
+        if not tags.get(resource_tags.IS_FRACTIONAL, False):
+            tags.pop(resource_tags.IS_FRACTIONAL, None)
+        return (
+            r.cpu,
+            r.gpu,
+            r.memMB,
+            PluginRegistry._normalize_value(r.capabilities),
+            PluginRegistry._normalize_value(r.devices),
+            PluginRegistry._normalize_value(tags),
+        )
+
+    @staticmethod
+    def _plugins_equal(a: Any, b: Any, plugin_type: PluginType) -> bool:
+        """Whether two same-name registrations are semantically identical.
+
+        The same callable object is always equal. NAMED_RESOURCE factories
+        are cheap and pure, so their equality is defined by the materialized
+        resource values under structural normalization (see
+        :py:meth:`_normalize_value`); a factory that raises is never equal.
+        Other plugin types (schedulers, trackers) are not safe to invoke at
+        discovery time, so distinct callables are never equal.
+        """
+        if a is b:
+            return True
+        if plugin_type == PluginType.NAMED_RESOURCE:
+            try:
+                va, vb = a(), b()
+                resource_attrs = (
+                    "cpu",
+                    "gpu",
+                    "memMB",
+                    "capabilities",
+                    "devices",
+                    "tags",
+                )
+                if all(hasattr(va, at) for at in resource_attrs) and all(
+                    hasattr(vb, at) for at in resource_attrs
+                ):
+                    return PluginRegistry._canonical_resource(
+                        va
+                    ) == PluginRegistry._canonical_resource(vb)
+                return PluginRegistry._normalize_value(
+                    va
+                ) == PluginRegistry._normalize_value(vb)
+            except Exception:
+                return False
+        return False
+
     def _collect_plugins_from_module(
         self,
         mod: ModuleType,
@@ -169,7 +289,21 @@ class PluginRegistry:
                 )
                 continue
             if plugin_name in discovered:
-                msg = "duplicate — already discovered, keeping first occurrence"
+                if self._plugins_equal(discovered[plugin_name], obj, actual_type):
+                    # same-name re-registration of an EQUAL value is
+                    # idempotent (e.g. two portions of the namespace shipping
+                    # the same resource) — keep the first, record nothing
+                    logger.debug(
+                        "plugin `%s` in `%s` re-registers an equal value"
+                        " — idempotent, keeping first occurrence",
+                        plugin_name,
+                        fqn,
+                    )
+                    continue
+                msg = (
+                    "duplicate — already discovered with a DIFFERENT value,"
+                    " keeping first occurrence"
+                )
                 logger.warning("duplicate plugin `%s` in `%s`", plugin_name, fqn)
                 self._errors.append(
                     RegistrationError(

--- a/torchx/plugins/test/registry_test.py
+++ b/torchx/plugins/test/registry_test.py
@@ -22,7 +22,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import patch
 
 from torchx.plugins._registration import register
@@ -835,3 +835,195 @@ class DiscoveryFaultToleranceTest(_RegistryTestBase):
             )
         finally:
             sys.modules.pop("torchx_plugins.broken_ns", None)
+
+
+class DuplicateIdempotenceTest(_RegistryTestBase):
+    """Same-name re-registration semantics: equal values are idempotent,
+    different values keep the duplicate error (fork-drift detection)."""
+
+    @staticmethod
+    def _fake_module(
+        mod_name: str, plugin_name: str, factory: Callable[[], object]
+    ) -> types.ModuleType:
+        factory._plugin_type = PluginType.NAMED_RESOURCE
+        factory._plugin_name = plugin_name
+        factory.__module__ = mod_name
+        factory.__name__ = plugin_name
+        mod = types.ModuleType(mod_name)
+        setattr(mod, plugin_name, factory)
+        return mod
+
+    def test_equal_value_reregistration_is_idempotent(self) -> None:
+        # in-function on purpose: importing torchx.specs runs plugin discovery at import time (eager
+        # _load_named_resources() at module scope); keep it under this test's isolation, not at module import.
+        from torchx.specs.api import Resource
+
+        def factory_a() -> Resource:
+            return Resource(cpu=1, gpu=0, memMB=1024)
+
+        def factory_b() -> Resource:
+            return Resource(cpu=1, gpu=0, memMB=1024)
+
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        discovered: dict[str, Any] = {}
+        mod_a = self._fake_module("portion_a.mod", "t_test", factory_a)
+        mod_b = self._fake_module("portion_b.mod", "t_test", factory_b)
+        reg._collect_plugins_from_module(
+            mod_a, "portion_a.mod", PluginType.NAMED_RESOURCE, discovered
+        )
+        reg._collect_plugins_from_module(
+            mod_b, "portion_b.mod", PluginType.NAMED_RESOURCE, discovered
+        )
+
+        self.assertEqual([], reg.errors, "equal re-registration must record no error")
+        self.assertIs(
+            discovered["t_test"],
+            mod_a.__dict__["t_test"],
+            "first occurrence must be kept",
+        )
+
+    def test_different_value_reregistration_keeps_error(self) -> None:
+        # in-function on purpose: importing torchx.specs runs plugin discovery at import time (eager
+        # _load_named_resources() at module scope); keep it under this test's isolation, not at module import.
+        from torchx.specs.api import Resource
+
+        def factory_a() -> Resource:
+            return Resource(cpu=1, gpu=0, memMB=1024)
+
+        def factory_b() -> Resource:
+            return Resource(cpu=2, gpu=0, memMB=2048)
+
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        discovered: dict[str, Any] = {}
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_a.mod", "t_test", factory_a),
+            "portion_a.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_b.mod", "t_test", factory_b),
+            "portion_b.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+
+        self.assertEqual(
+            1, len(reg.errors), "a DIFFERENT value must keep the duplicate error"
+        )
+        self.assertIn("DIFFERENT value", reg.errors[0].error)
+
+    def test_raising_factory_is_never_equal(self) -> None:
+        # in-function on purpose: importing torchx.specs runs plugin discovery at import time (eager
+        # _load_named_resources() at module scope); keep it under this test's isolation, not at module import.
+        from torchx.specs.api import Resource
+
+        def factory_a() -> Resource:
+            return Resource(cpu=1, gpu=0, memMB=1024)
+
+        def factory_b() -> Resource:
+            raise RuntimeError("cannot materialize")
+
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        discovered: dict[str, Any] = {}
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_a.mod", "t_test", factory_a),
+            "portion_a.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_b.mod", "t_test", factory_b),
+            "portion_b.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+
+        self.assertEqual(
+            1, len(reg.errors), "a raising factory must keep the duplicate error"
+        )
+
+    def test_twin_generated_types_compare_semantically(self) -> None:
+        """Enums regenerated per-distribution (thrift mirrors) defeat `==` by
+        class identity; the normalized comparison must treat equal-valued
+        twins as equal, and an explicit `is_fractional: False` tag as absent."""
+        import enum as _enum
+
+        from torchx.plugins._registration import resource_tags
+
+        # in-function on purpose: importing torchx.specs runs plugin discovery at import time (eager
+        # _load_named_resources() at module scope); keep it under this test's isolation, not at module import.
+        from torchx.specs.api import Resource
+
+        # twin generated modules re-declare the SAME-named enum class; mint
+        # two distinct classes sharing name and values to simulate that
+        def _twin_enum() -> type[_enum.Enum]:
+            class LogicalServerType(_enum.Enum):
+                T1 = 100
+
+            return LogicalServerType
+
+        ServerTypeA: type[_enum.Enum] = _twin_enum()
+        ServerTypeB: type[_enum.Enum] = _twin_enum()
+
+        def factory_a() -> Resource:
+            return Resource(
+                cpu=1,
+                gpu=0,
+                memMB=1024,
+                capabilities={"server_types": [ServerTypeA["T1"]]},
+                tags={"torchx/named_resources.name": "t_test"},
+            )
+
+        def factory_b() -> Resource:
+            return Resource(
+                cpu=1,
+                gpu=0,
+                memMB=1024,
+                capabilities={"server_types": [ServerTypeB["T1"]]},
+                tags={
+                    "torchx/named_resources.name": "t_test",
+                    resource_tags.IS_FRACTIONAL: False,
+                },
+            )
+
+        self.assertNotEqual(
+            factory_a(), factory_b(), "plain == must fail on twin enums (premise)"
+        )
+
+        reg = PluginRegistry(plugin_sources=PluginSource.NAMESPACE_PKG)
+        discovered: dict[str, Any] = {}
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_a.mod", "t_test", factory_a),
+            "portion_a.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+        reg._collect_plugins_from_module(
+            self._fake_module("portion_b.mod", "t_test", factory_b),
+            "portion_b.mod",
+            PluginType.NAMED_RESOURCE,
+            discovered,
+        )
+
+        self.assertEqual([], reg.errors, "semantically equal twins must be idempotent")
+
+    def test_equal_sets_normalize_equal_regardless_of_insertion_order(self) -> None:
+        """Set iteration order depends on insertion history (`{0, 8}` vs
+        `{8, 0}` collide into the same hash slot), so an unsorted
+        normalization mints false different-value duplicates."""
+        set_a = {0, 8}
+        set_b = {8, 0}
+        self.assertEqual(set_a, set_b, "premise: the sets are equal")
+        self.assertNotEqual(
+            list(set_a), list(set_b), "premise: iteration orders differ"
+        )
+
+        self.assertEqual(
+            PluginRegistry._normalize_value(set_a),
+            PluginRegistry._normalize_value(set_b),
+        )
+        self.assertEqual(
+            PluginRegistry._normalize_value(frozenset(set_a)),
+            PluginRegistry._normalize_value(frozenset(set_b)),
+        )


### PR DESCRIPTION
Summary:

When the same plugin is importable through two channels (e.g. installed as a wheel AND present on the source tree), discovery sees it twice — both channels register the same name with the same value:

```python
# portion_a/mod.py AND portion_b/mod.py — same plugin, two install channels
def t_test() -> Resource:
    return Resource(cpu=1, gpu=0, memMB=1024)
```

**Before** — the second registration was recorded as an error, so consumers that assert clean discovery failed on a perfectly healthy install:

```
>>> registry().errors
[RegistrationError(module="portion_b.mod", name="t_test",
    error="duplicate — already discovered, keeping first occurrence")]
```

**After** — an equal-value re-registration is a no-op (first occurrence kept):

```
>>> registry().errors
[]
```

**Root cause:** the duplicate check compared names only, never values, so a benign double-install was indistinguishable from a real conflict. A DIFFERENT value under the same name still records the error (message now says "with a DIFFERENT value") — that is real drift and must stay loud.

NOTE: equality invokes the two factories and compares the materialized resources under structural normalization, because thrift enums/structs regenerated per distribution defeat `==` by class identity even on identical data. `NAMED_RESOURCE` only — factories are cheap and pure; schedulers/trackers are never invoked, so their distinct callables still error.

Differential Revision: D116171124
