### PR TITLE
(cleanup)[3/5][torchx][specs] AppDryRunInfo.app/cfg as plain attributes (#1400)

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -223,7 +223,7 @@ class CmdRunTest(unittest.TestCase):
 
         app_run_info_stub = AppDryRunInfo("req", lambda x: x)
         req_type_dataclass = dataclasses.make_dataclass("T", [])
-        app_run_info_stub._app = req_type_dataclass()
+        app_run_info_stub.app = req_type_dataclass()
         mock_runner_run.return_value = app_run_info_stub
 
         self.cmd_run.run(args)
@@ -447,7 +447,7 @@ component = custom.echo
     def test_run_inner_local_scheduler_warns_deprecation(self) -> None:
         runner = MagicMock()
         dryrun_info_stub = AppDryRunInfo("req", lambda x: x)
-        dryrun_info_stub._app = dataclasses.make_dataclass("T", [])()
+        dryrun_info_stub.app = dataclasses.make_dataclass("T", [])()
         runner.dryrun_component.return_value = dryrun_info_stub
         run_args = TorchXRunArgs(
             component_name="utils.echo",

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -429,8 +429,8 @@ class Scheduler(abc.ABC, Generic[T]):
         for role in app.roles:
             dryrun_info = role.pre_proc(self.backend, dryrun_info)
 
-        dryrun_info._app = app
-        dryrun_info._cfg = resolved_cfg
+        dryrun_info.app = app
+        dryrun_info.cfg = resolved_cfg
         return dryrun_info
 
     @abc.abstractmethod

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from enum import Enum
 from json import JSONDecodeError
 from string import Template
-from types import MappingProxyType
 from typing import (
     Any,
     Awaitable,
@@ -1005,36 +1004,24 @@ class AppDryRunInfo(Generic[T]):
     <torchx.schedulers.api.Scheduler.describe_native>` (the request read back
     from the scheduler for an already-submitted app).
     ``print(info)`` yields a human-readable representation.
+
+    Attributes:
+        request: The scheduler-specific submit request.
+        app: The resolved :py:class:`AppDef` ``request`` was rendered from.
+            ``None`` until set by :py:meth:`Runner.dryrun
+            <torchx.runner.Runner.dryrun>` or :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+        cfg: The resolved run config (defaults applied). Empty until set
+            alongside ``app``.
     """
 
     def __init__(self, request: T, fmt: Callable[[T], str]) -> None:
         self.request = request
+        self.app: AppDef | None = None
+        self.cfg: Mapping[str, CfgVal] = {}
+
         self._fmt = fmt
-
-        # back references to the parameters of the dryrun() call that
-        # returned this AppDryRunInfo object; set in Runner.dryrun() and
-        # Scheduler.submit_dryrun() manually rather than through constructor
-        # arguments. Read them via the `app` and `cfg` properties;
-        # `_scheduler` is only meant for Scheduler/Runner implementations.
-        self._app: AppDef | None = None
-        self._cfg: Mapping[str, CfgVal] = {}
         self._scheduler: str | None = None
-
-    @property
-    def app(self) -> AppDef | None:
-        """The :py:class:`AppDef` this dryrun info was created from.
-
-        ``None`` until set by ``Runner.dryrun()`` / ``Scheduler.submit_dryrun()``.
-        """
-        return self._app
-
-    @property
-    def cfg(self) -> Mapping[str, CfgVal]:
-        """Read-only view of the resolved scheduler run config.
-
-        Mutating the returned mapping raises ``TypeError``.
-        """
-        return MappingProxyType(self._cfg)
 
     def __repr__(self) -> str:
         return self._fmt(self.request)

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -17,7 +17,7 @@ import time
 import unittest
 from dataclasses import asdict
 from pathlib import Path
-from typing import cast, Dict, List, Mapping, Union
+from typing import Dict, List, Mapping, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -189,32 +189,18 @@ class AppDryRunInfoTest(unittest.TestCase):
 
         to_string_mock.assert_called_once_with(request_mock)
 
-    def test_app_and_cfg_accessors(self) -> None:
+    def test_app_and_cfg_defaults(self) -> None:
         info = AppDryRunInfo(MagicMock(), repr)
 
         self.assertIsNone(info.app, "app should be None until set by dryrun")
         self.assertEqual({}, dict(info.cfg), "cfg should default to empty")
 
         app = AppDef(name="test_app")
-        info._app = app
-        info._cfg = {"cluster": "foo", "priority": 1}
+        info.app = app
+        info.cfg = {"cluster": "foo", "priority": 1}
 
-        self.assertIs(app, info.app, "app property should return the AppDef")
-        self.assertEqual(
-            {"cluster": "foo", "priority": 1},
-            dict(info.cfg),
-            "cfg property should reflect the resolved cfg",
-        )
-
-    def test_cfg_is_read_only(self) -> None:
-        info = AppDryRunInfo(MagicMock(), repr)
-        info._cfg = {"cluster": "foo"}
-
-        # cast defeats the static Mapping protocol (no `__setitem__`) so the
-        # RUNTIME read-only guarantee (MappingProxyType) is what's exercised
-        cfg = cast(dict[str, CfgVal], info.cfg)
-        with self.assertRaises(TypeError, msg="mutating cfg view must raise"):
-            cfg["cluster"] = "bar"
+        self.assertIs(app, info.app)
+        self.assertEqual({"cluster": "foo", "priority": 1}, dict(info.cfg))
 
 
 class AppDefStatusTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/4696


`AppDryRunInfo` declares `request` as a plain attribute but `app` and `cfg` as read-only properties over `_app`/`_cfg`, so the scheduler filling them in reaches through the underscore names:

**Before**

```lang=python
dryrun_info._app = app
dryrun_info._cfg = resolved_cfg  # .app / .cfg are read-only properties
```

**After**

```lang=python
dryrun_info.app = app
dryrun_info.cfg = resolved_cfg
```

Trade-off: `cfg` hands back the plain mapping, so mutation is rejected by the `Mapping[str, CfgVal]` annotation but not at runtime. A guard on one of three sibling attributes costs more in surface inconsistency than it buys.

Carries only the call sites that cannot migrate ahead of it: every `_app`/`_cfg` **writer** (assigning to a setter-less property raises) and the two `_cfg` readers that `json.dumps` the value (`MappingProxyType` is not JSON-serializable).

One writer is deleted, not migrated: `monarch/_src/tools/commands.py` exports to `meta-pytorch/monarch`, which resolves `torchx` from unpinned `torchx-nightly`, so a public-attribute write raises there until that nightly publishes. `create()` now swaps the formatter on the dryrun info in place instead of copy-constructing one and re-attaching `app`/`cfg`/`_scheduler`.

Differential Revision: D116707596
