### PR TITLE
(docs)[4/5][torchx] Document whether dryrun/submit_dryrun mutate the caller's AppDef (#1401)

### DIFF
--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -63,6 +63,22 @@ When ``workspace=`` is passed to :py:meth:`~torchx.runner.Runner.run` (or
    :py:meth:`~torchx.workspace.WorkspaceMixin.push_images` handle pushing
    the built image to a remote registry.
 
+.. important::
+
+   The role mutated in step 3 belongs to a **copy** of your
+   :py:class:`~torchx.specs.AppDef` that
+   :py:meth:`~torchx.runner.Runner.dryrun` takes before patching -- your own
+   ``AppDef`` still carries the image you authored. To see what was actually
+   submitted, read :py:attr:`~torchx.specs.AppDryRunInfo.app`:
+
+   .. code-block:: python
+
+      info = runner.dryrun(app, "kubernetes", cfg)
+      info.app.roles[0].image  # patched; app.roles[0].image is not
+
+   :py:meth:`~torchx.schedulers.api.Scheduler.submit` takes no such copy and
+   patches the ``AppDef`` you hand it.
+
 .. note::
 
    ``DockerWorkspaceMixin`` uses ``Dockerfile.torchx`` from the workspace root

--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -223,7 +223,7 @@ class CmdRunTest(unittest.TestCase):
 
         app_run_info_stub = AppDryRunInfo("req", lambda x: x)
         req_type_dataclass = dataclasses.make_dataclass("T", [])
-        app_run_info_stub._app = req_type_dataclass()
+        app_run_info_stub.app = req_type_dataclass()
         mock_runner_run.return_value = app_run_info_stub
 
         self.cmd_run.run(args)
@@ -447,7 +447,7 @@ component = custom.echo
     def test_run_inner_local_scheduler_warns_deprecation(self) -> None:
         runner = MagicMock()
         dryrun_info_stub = AppDryRunInfo("req", lambda x: x)
-        dryrun_info_stub._app = dataclasses.make_dataclass("T", [])()
+        dryrun_info_stub.app = dataclasses.make_dataclass("T", [])()
         runner.dryrun_component.return_value = dryrun_info_stub
         run_args = TorchXRunArgs(
             component_name="utils.echo",

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -269,11 +269,20 @@ class Runner:
             info = runner.run(app, "mkube", cfg=cfg, dryrun=True)
             print(info)
 
+        **Does not mutate** *app* -- see :py:meth:`dryrun`, which this delegates
+        to. The workspace build and env injection land on an internal deep copy:
+        with ``dryrun=True`` that copy comes back as ``info.app``; with
+        ``dryrun=False`` it is submitted and dropped, and only the
+        :py:data:`~torchx.specs.AppHandle` is returned.
+
         Args:
             dryrun: If ``True``, only validate and render the request
                 without submitting.  Returns :py:class:`~torchx.specs.AppDryRunInfo`.
                 If ``False`` (default), submit and return the
                 :py:data:`~torchx.specs.AppHandle`.
+
+        Raises:
+            ValueError: propagated from :py:meth:`dryrun`.
         """
 
         with log_event(api="run") as ctx:
@@ -311,6 +320,9 @@ class Runner:
 
         .. warning:: Use sparingly. Overwriting many raw scheduler fields may
                      cause your usage to diverge from TorchX's supported API.
+
+        Only ``dryrun_info.request`` is submitted; edits to ``dryrun_info.app``
+        made after :py:meth:`dryrun` returned are **not** re-rendered into it.
         """
         scheduler = none_throws(dryrun_info._scheduler)
         cfg = dryrun_info.cfg
@@ -346,11 +358,52 @@ class Runner:
 
         The returned :py:class:`~torchx.specs.AppDryRunInfo` can be
         ``print()``-ed for inspection or passed to :py:meth:`schedule`.
+
+        **Does not mutate** *app*. The patching this method performs -- building
+        each role's :py:attr:`~torchx.specs.Role.workspace` and repointing
+        ``role.image`` at the built artifact, injecting the ``TORCHX_*`` tracking
+        env vars -- lands on a deep copy, which is returned as
+        :py:attr:`~torchx.specs.AppDryRunInfo.app`. Read the submitted images off
+        that copy, never off the *app* you passed in:
+
+        .. code-block:: python
+
+            app = AppDef(roles=[Role(image="foo:latest", workspace=..., ...)])
+            info = runner.dryrun(app, "kubernetes")
+
+            app.roles[0].image       # "foo:latest" -- unpatched, as authored
+            info.app.roles[0].image  # "foo:<built-workspace-hash>" -- submitted
+
+        ``Role.overrides`` is the one part not copied: the same dict object is
+        shared by the caller's role and the copy, so resolving an override
+        through either is visible to both.
+
+        Two dryruns of the same *app* need not render the same request -- each
+        rebuilds the workspace, and the build may produce a new image. Re-running
+        from the returned copy does not skip that build either, because
+        :py:attr:`~torchx.specs.Role.workspace` is left set after one; it only
+        narrows the difference down to the build, since every other patch is
+        already applied. Clear the workspace to render the exact same request:
+
+        .. code-block:: python
+
+            info1 = runner.dryrun(app, "kubernetes", cfg)
+
+            for role in info1.app.roles:
+                role.workspace = None
+
+            info2 = runner.dryrun(info1.app, "kubernetes", info1.cfg)
+            assert info1.request == info2.request
+
+        Raises:
+            ValueError: *app* has no roles, or a role has no ``entrypoint`` or
+                a non-positive ``num_replicas``. Schedulers raise from their own
+                ``_validate`` hooks for backend-specific violations.
         """
         # operate on a copy so that the env injection and workspace overwrite
         # below never leak into the caller's AppDef (one AppDef can be
-        # dry-run multiple times); the copy rides in the returned
-        # AppDryRunInfo's `_app`.
+        # dry-run multiple times); the copy is returned as the AppDryRunInfo's
+        # `app`.
         #
         # Role.overrides may already hold non-deepcopyable values (e.g. APF
         # attaches an in-flight fbpkg Future before calling dryrun), so mirror

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -429,8 +429,8 @@ class Scheduler(abc.ABC, Generic[T]):
         for role in app.roles:
             dryrun_info = role.pre_proc(self.backend, dryrun_info)
 
-        dryrun_info._app = app
-        dryrun_info._cfg = resolved_cfg
+        dryrun_info.app = app
+        dryrun_info.cfg = resolved_cfg
         return dryrun_info
 
     @abc.abstractmethod

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -395,7 +395,19 @@ class Scheduler(abc.ABC, Generic[T]):
         cfg: T,
         workspace: str | Workspace | None = None,
     ) -> str:
-        """Submits an app directly. Prefer :py:meth:`~torchx.runner.api.Runner.run` for production use."""
+        """Submits an app directly. Prefer :py:meth:`~torchx.runner.api.Runner.run` for production use.
+
+        **Mutates** *app*: unlike :py:meth:`~torchx.runner.api.Runner.run`, no copy
+        is taken, so every write lands on the caller's own object. Passing
+        *workspace* sets ``app.roles[0].workspace`` and repoints
+        ``app.roles[*].image`` at the build; without it nothing is built, and a
+        role carrying its own :py:attr:`~torchx.specs.Role.workspace` reaches
+        :py:meth:`_submit_dryrun` unbuilt.
+
+        Raises:
+            ValueError: *workspace* was passed but this scheduler is not a
+                :py:class:`~torchx.workspace.WorkspaceMixin`.
+        """
         # pyre-fixme: Generic cfg type passed to resolve
         resolved_cfg = self.run_opts().resolve(cfg)
         if workspace:
@@ -420,7 +432,19 @@ class Scheduler(abc.ABC, Generic[T]):
         raise NotImplementedError()
 
     def submit_dryrun(self, app: AppDef, cfg: T) -> AppDryRunInfo:
-        """Returns the scheduler request without submitting."""
+        """Returns the scheduler request without submitting.
+
+        **No copy is taken**: the returned
+        :py:attr:`~torchx.specs.AppDryRunInfo.app` *is* the *app* passed in, and
+        :py:meth:`_submit_dryrun` and each role's ``pre_proc`` may mutate it.
+        Callers wanting their :py:class:`~torchx.specs.AppDef` left alone should
+        go through :py:meth:`~torchx.runner.api.Runner.dryrun`, which copies
+        first.
+
+        :py:attr:`~torchx.specs.AppDryRunInfo.cfg` is *cfg* with this
+        scheduler's :py:meth:`run_opts` defaults applied, so it is not
+        necessarily the mapping that was passed in.
+        """
         # pyre-fixme: Generic cfg type passed to resolve
         resolved_cfg = self.run_opts().resolve(cfg)
         # pyre-fixme: _submit_dryrun takes Generic type for resolved_cfg
@@ -435,6 +459,22 @@ class Scheduler(abc.ABC, Generic[T]):
 
     @abc.abstractmethod
     def _submit_dryrun(self, app: AppDef, cfg: T) -> AppDryRunInfo:
+        """Renders *app* into this backend's submit request.
+
+        Implementations receive *cfg* already resolved against
+        :py:meth:`run_opts` and read ``role.image`` as final -- building a
+        role's workspace is never their job. Reached through
+        :py:meth:`~torchx.runner.api.Runner.dryrun`, or through
+        :py:meth:`submit` with a *workspace*, that build has already happened
+        and ``role.image`` points at its result; a caller who invokes
+        :py:meth:`submit_dryrun` directly can still hand over roles whose
+        ``workspace`` was never built.
+
+        Mutating *app* is permitted (the caller owns no copy) but discouraged:
+        prefer rendering into the returned
+        :py:class:`~torchx.specs.AppDryRunInfo`. Do not set its ``app``/``cfg``
+        attributes -- :py:meth:`submit_dryrun` does that.
+        """
         raise NotImplementedError()
 
     def run_opts(self) -> runopts:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from enum import Enum
 from json import JSONDecodeError
 from string import Template
-from types import MappingProxyType
 from typing import (
     Any,
     Awaitable,
@@ -1005,36 +1004,24 @@ class AppDryRunInfo(Generic[T]):
     <torchx.schedulers.api.Scheduler.describe_native>` (the request read back
     from the scheduler for an already-submitted app).
     ``print(info)`` yields a human-readable representation.
+
+    Attributes:
+        request: The scheduler-specific submit request.
+        app: The resolved :py:class:`AppDef` ``request`` was rendered from.
+            ``None`` until set by :py:meth:`Runner.dryrun
+            <torchx.runner.Runner.dryrun>` or :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+        cfg: The resolved run config (defaults applied). Empty until set
+            alongside ``app``.
     """
 
     def __init__(self, request: T, fmt: Callable[[T], str]) -> None:
         self.request = request
+        self.app: AppDef | None = None
+        self.cfg: Mapping[str, CfgVal] = {}
+
         self._fmt = fmt
-
-        # back references to the parameters of the dryrun() call that
-        # returned this AppDryRunInfo object; set in Runner.dryrun() and
-        # Scheduler.submit_dryrun() manually rather than through constructor
-        # arguments. Read them via the `app` and `cfg` properties;
-        # `_scheduler` is only meant for Scheduler/Runner implementations.
-        self._app: AppDef | None = None
-        self._cfg: Mapping[str, CfgVal] = {}
         self._scheduler: str | None = None
-
-    @property
-    def app(self) -> AppDef | None:
-        """The :py:class:`AppDef` this dryrun info was created from.
-
-        ``None`` until set by ``Runner.dryrun()`` / ``Scheduler.submit_dryrun()``.
-        """
-        return self._app
-
-    @property
-    def cfg(self) -> Mapping[str, CfgVal]:
-        """Read-only view of the resolved scheduler run config.
-
-        Mutating the returned mapping raises ``TypeError``.
-        """
-        return MappingProxyType(self._cfg)
 
     def __repr__(self) -> str:
         return self._fmt(self.request)

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1008,11 +1008,20 @@ class AppDryRunInfo(Generic[T]):
     Attributes:
         request: The scheduler-specific submit request.
         app: The resolved :py:class:`AppDef` ``request`` was rendered from.
-            ``None`` until set by :py:meth:`Runner.dryrun
-            <torchx.runner.Runner.dryrun>` or :py:meth:`Scheduler.submit_dryrun
-            <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+            ``None`` until set by :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>`. What it carries
+            depends on the entry point: via :py:meth:`Runner.dryrun
+            <torchx.runner.Runner.dryrun>` it is a private copy, patched with
+            the built workspace image and the injected ``TORCHX_*`` env vars,
+            leaving the caller's own untouched; via
+            :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>` directly it is the
+            very object passed in, with neither step applied.
         cfg: The resolved run config (defaults applied). Empty until set
-            alongside ``app``.
+            alongside ``app``. Not a copy either: it is the same mapping the
+            scheduler was handed, so mutating it in place reaches whatever the
+            scheduler retained. The ``Mapping`` annotation is the only thing
+            saying not to.
     """
 
     def __init__(self, request: T, fmt: Callable[[T], str]) -> None:

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -17,7 +17,7 @@ import time
 import unittest
 from dataclasses import asdict
 from pathlib import Path
-from typing import cast, Dict, List, Mapping, Union
+from typing import Dict, List, Mapping, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -189,32 +189,18 @@ class AppDryRunInfoTest(unittest.TestCase):
 
         to_string_mock.assert_called_once_with(request_mock)
 
-    def test_app_and_cfg_accessors(self) -> None:
+    def test_app_and_cfg_defaults(self) -> None:
         info = AppDryRunInfo(MagicMock(), repr)
 
         self.assertIsNone(info.app, "app should be None until set by dryrun")
         self.assertEqual({}, dict(info.cfg), "cfg should default to empty")
 
         app = AppDef(name="test_app")
-        info._app = app
-        info._cfg = {"cluster": "foo", "priority": 1}
+        info.app = app
+        info.cfg = {"cluster": "foo", "priority": 1}
 
-        self.assertIs(app, info.app, "app property should return the AppDef")
-        self.assertEqual(
-            {"cluster": "foo", "priority": 1},
-            dict(info.cfg),
-            "cfg property should reflect the resolved cfg",
-        )
-
-    def test_cfg_is_read_only(self) -> None:
-        info = AppDryRunInfo(MagicMock(), repr)
-        info._cfg = {"cluster": "foo"}
-
-        # cast defeats the static Mapping protocol (no `__setitem__`) so the
-        # RUNTIME read-only guarantee (MappingProxyType) is what's exercised
-        cfg = cast(dict[str, CfgVal], info.cfg)
-        with self.assertRaises(TypeError, msg="mutating cfg view must raise"):
-            cfg["cluster"] = "bar"
+        self.assertIs(app, info.app)
+        self.assertEqual({"cluster": "foo", "priority": 1}, dict(info.cfg))
 
 
 class AppDefStatusTest(unittest.TestCase):

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -99,7 +99,14 @@ class WorkspaceMixin(abc.ABC, Generic[T]):
 
         .. important::
             Mutates the passed *roles*. May also add env vars (e.g. ``WORKSPACE_DIR``)
-            to ``role.env``.
+            to ``role.env``. ``role.workspace`` is left set, so a role that has
+            been through this method is not distinguishable by inspection from
+            one that has not -- compare ``role.image`` instead.
+
+        Called by :py:meth:`~torchx.runner.api.Runner.dryrun` with the roles of
+        its private copy, so the caller's :py:class:`~torchx.specs.AppDef` is
+        unaffected there; :py:meth:`~torchx.schedulers.api.Scheduler.submit`
+        passes the caller's own roles.
         """
 
         build_cache: dict[object, object] = {}


### PR DESCRIPTION
Summary:

`Runner.dryrun()` and `Scheduler.submit_dryrun()` disagree on whether they
mutate the `AppDef` you hand them, and neither said so. So reading `role.image`
back off your own `AppDef` after `runner.dryrun()` returns the image you
authored, not the one that will be submitted:

```python
app = AppDef(roles=[Role(image="foo:latest", workspace=..., ...)])
info = runner.dryrun(app, "mast")

app.roles[0].image       # "foo:latest"            <- as authored
info.app.roles[0].image  # "foo:<workspace-hash>"  <- actually submitted
```

That read is what sent 44 multi-region jobs to a stale `:latest`.

| Call | Caller's `AppDef` | `info.app` is |
|---|---|---|
| `Runner.dryrun` / `run` | untouched | a private copy |
| `Scheduler.submit_dryrun` | mutated | the object passed in |
| `Scheduler.submit` | mutated | n/a |

Four more aliasing/defaulting surprises get the same treatment, in the
docstrings rather than here: shared `Role.overrides`, `run_opts()` defaults in
`info.cfg`, `role.workspace` surviving a build, and `dryrun`'s `ValueError`s.

`_submit_dryrun` names the paths that guarantee its roles arrive built, rather
than claiming they always do — a direct `submit_dryrun` caller can still pass an
unbuilt `role.workspace`.

Examples are `.. code-block::` rather than `.. doctest::` because they need a
live scheduler.

Reviewed By: athmasagar

Differential Revision: D116718390


