### PR TITLE
Add `Runner.build_workspace()` to build a workspace image once and reuse it (#1402)

### DIFF
--- a/docs/source/workspace.rst
+++ b/docs/source/workspace.rst
@@ -63,6 +63,22 @@ When ``workspace=`` is passed to :py:meth:`~torchx.runner.Runner.run` (or
    :py:meth:`~torchx.workspace.WorkspaceMixin.push_images` handle pushing
    the built image to a remote registry.
 
+.. important::
+
+   The role mutated in step 3 belongs to a **copy** of your
+   :py:class:`~torchx.specs.AppDef` that
+   :py:meth:`~torchx.runner.Runner.dryrun` takes before patching -- your own
+   ``AppDef`` still carries the image you authored. To see what was actually
+   submitted, read :py:attr:`~torchx.specs.AppDryRunInfo.app`:
+
+   .. code-block:: python
+
+      info = runner.dryrun(app, "kubernetes", cfg)
+      info.app.roles[0].image  # patched; app.roles[0].image is not
+
+   :py:meth:`~torchx.schedulers.api.Scheduler.submit` takes no such copy and
+   patches the ``AppDef`` you hand it.
+
 .. note::
 
    ``DockerWorkspaceMixin`` uses ``Dockerfile.torchx`` from the workspace root

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -269,11 +269,20 @@ class Runner:
             info = runner.run(app, "mkube", cfg=cfg, dryrun=True)
             print(info)
 
+        **Does not mutate** *app* -- see :py:meth:`dryrun`, which this delegates
+        to. The workspace build and env injection land on an internal deep copy:
+        with ``dryrun=True`` that copy comes back as ``info.app``; with
+        ``dryrun=False`` it is submitted and dropped, and only the
+        :py:data:`~torchx.specs.AppHandle` is returned.
+
         Args:
             dryrun: If ``True``, only validate and render the request
                 without submitting.  Returns :py:class:`~torchx.specs.AppDryRunInfo`.
                 If ``False`` (default), submit and return the
                 :py:data:`~torchx.specs.AppHandle`.
+
+        Raises:
+            ValueError: propagated from :py:meth:`dryrun`.
         """
 
         with log_event(api="run") as ctx:
@@ -311,6 +320,9 @@ class Runner:
 
         .. warning:: Use sparingly. Overwriting many raw scheduler fields may
                      cause your usage to diverge from TorchX's supported API.
+
+        Only ``dryrun_info.request`` is submitted; edits to ``dryrun_info.app``
+        made after :py:meth:`dryrun` returned are **not** re-rendered into it.
         """
         scheduler = none_throws(dryrun_info._scheduler)
         cfg = dryrun_info.cfg
@@ -346,11 +358,52 @@ class Runner:
 
         The returned :py:class:`~torchx.specs.AppDryRunInfo` can be
         ``print()``-ed for inspection or passed to :py:meth:`schedule`.
+
+        **Does not mutate** *app*. The patching this method performs -- building
+        each role's :py:attr:`~torchx.specs.Role.workspace` and repointing
+        ``role.image`` at the built artifact, injecting the ``TORCHX_*`` tracking
+        env vars -- lands on a deep copy, which is returned as
+        :py:attr:`~torchx.specs.AppDryRunInfo.app`. Read the submitted images off
+        that copy, never off the *app* you passed in:
+
+        .. code-block:: python
+
+            app = AppDef(roles=[Role(image="foo:latest", workspace=..., ...)])
+            info = runner.dryrun(app, "kubernetes")
+
+            app.roles[0].image       # "foo:latest" -- unpatched, as authored
+            info.app.roles[0].image  # "foo:<built-workspace-hash>" -- submitted
+
+        ``Role.overrides`` is the one part not copied: the same dict object is
+        shared by the caller's role and the copy, so resolving an override
+        through either is visible to both.
+
+        Two dryruns of the same *app* need not render the same request -- each
+        rebuilds the workspace, and the build may produce a new image. Re-running
+        from the returned copy does not skip that build either, because
+        :py:attr:`~torchx.specs.Role.workspace` is left set after one; it only
+        narrows the difference down to the build, since every other patch is
+        already applied. Clear the workspace to render the exact same request:
+
+        .. code-block:: python
+
+            info1 = runner.dryrun(app, "kubernetes", cfg)
+
+            for role in info1.app.roles:
+                role.workspace = None
+
+            info2 = runner.dryrun(info1.app, "kubernetes", info1.cfg)
+            assert info1.request == info2.request
+
+        Raises:
+            ValueError: *app* has no roles, or a role has no ``entrypoint`` or
+                a non-positive ``num_replicas``. Schedulers raise from their own
+                ``_validate`` hooks for backend-specific violations.
         """
         # operate on a copy so that the env injection and workspace overwrite
         # below never leak into the caller's AppDef (one AppDef can be
-        # dry-run multiple times); the copy rides in the returned
-        # AppDryRunInfo's `_app`.
+        # dry-run multiple times); the copy is returned as the AppDryRunInfo's
+        # `app`.
         #
         # Role.overrides may already hold non-deepcopyable values (e.g. APF
         # attaches an in-flight fbpkg Future before calling dryrun), so mirror

--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
+import contextlib
 import copy
+import dataclasses
 import json
 import logging
 import os
@@ -17,6 +19,7 @@ from types import TracebackType
 from typing import (
     Any,
     Iterable,
+    Iterator,
     Literal,
     Mapping,
     overload,
@@ -39,6 +42,7 @@ from torchx.specs import (
     make_app_handle,
     materialize_appdef,
     parse_app_handle,
+    Role,
     runopts,
     UnknownAppException,
     UnknownSchedulerException,
@@ -61,6 +65,42 @@ logger: logging.Logger = logging.getLogger(__name__)
 NONE: str = "<NONE>"
 S = TypeVar("S")
 T = TypeVar("T")
+
+
+@contextlib.contextmanager
+def _overrides_detached(roles: list[Role]) -> Iterator[list[dict[str, Any]]]:
+    """Strips ``overrides`` off *roles* for the duration, yielding the dicts.
+
+    ``Role.overrides`` may hold non-deepcopyable values (APF attaches an
+    in-flight fbpkg Future), so a ``deepcopy`` of anything owning a role runs
+    with them detached -- as ``macros.Values.apply`` does. Attach the yielded
+    dicts (the SAME objects) to the copy's roles: resolution writes back in
+    place, so sharing lets whichever owner resolves first serve both.
+    """
+    detached = [role.overrides for role in roles]
+    for role in roles:
+        role.overrides = {}
+    try:
+        yield detached
+    finally:
+        for role, overrides in zip(roles, detached):
+            role.overrides = overrides
+
+
+def _built_only_the_image(authored: Role, built: Role) -> bool:
+    """Whether building *authored*'s workspace changed nothing but ``image``.
+
+    Builders that also write to the role (``env`` pointing at the unpacked
+    workspace, say) produce a build the image alone cannot carry.
+
+    Fields are compared with ``==``, so a field type without value equality
+    can only turn this ``False`` -- costing a rebuild, never a bad pin.
+    """
+    return all(
+        getattr(authored, f.name) == getattr(built, f.name)
+        for f in dataclasses.fields(type(authored))
+        if f.name != "image"
+    )
 
 
 def get_configured_trackers() -> dict[str, str | None]:
@@ -346,6 +386,112 @@ class Runner:
     def name(self) -> str:
         return self._name
 
+    @overload
+    def build_workspace(
+        self,
+        app_or_role: Role,
+        scheduler: str,
+        cfg: Mapping[str, CfgVal] | None = None,
+    ) -> str | None: ...
+
+    @overload
+    def build_workspace(
+        self,
+        app_or_role: AppDef,
+        scheduler: str,
+        cfg: Mapping[str, CfgVal] | None = None,
+    ) -> dict[tuple[str, Workspace], str]: ...
+
+    def build_workspace(
+        self,
+        app_or_role: AppDef | Role,
+        scheduler: str,
+        cfg: Mapping[str, CfgVal] | None = None,
+    ) -> dict[tuple[str, Workspace], str] | str | None:
+        """Builds the workspaces and returns the images they were built into.
+
+        **Does not mutate** *app_or_role* -- the build runs against a deep copy.
+        Use this to build once and submit the result many times, instead of
+        letting each :py:meth:`run` rebuild:
+
+        .. code-block:: python
+
+            images = runner.build_workspace(app, "kubernetes", cfg)
+            for app in per_region_apps:
+                pin_workspace_images(app, images)
+                runner.run(app, "kubernetes", cfg)
+
+        Given a :py:class:`~torchx.specs.Role`, returns that role's built image,
+        or ``None`` if it has no :py:attr:`~torchx.specs.Role.workspace`. Given
+        an :py:class:`~torchx.specs.AppDef`, returns ``{(image, workspace): built}``
+        for the roles that have one -- keyed by the pair, not by role name, so the
+        result can be pinned onto a *different* ``AppDef``. A build installs the
+        workspace into ``role.image``, so the base image is half the key: roles
+        sharing a workspace but not an image build to different results, and roles
+        sharing both are built once. Both key halves come from the role as
+        *authored*, which the build does not overwrite. The pair is the widest
+        key correct for every builder, so one that caches more coarsely than the
+        exact image (on the fbpkg name, say) may rebuild where it could have
+        shared -- reuse is missed, never misapplied.
+
+        Only :py:attr:`~torchx.specs.Role.workspace` is read. The deprecated
+        ``workspace=`` argument to :py:meth:`run`/:py:meth:`dryrun` is applied
+        inside ``dryrun``, too late to prebuild here; set the role attribute
+        instead.
+
+        Unlike :py:meth:`dryrun`, this neither validates *app_or_role* nor
+        renders a scheduler request, so it does not fail on request-level
+        problems that are unrelated to building.
+
+        A role is omitted (with a warning) when its build wrote to the role
+        beyond ``image`` -- ``env``, say. Pinning cannot replay those writes, so
+        such a role keeps its workspace and rebuilds on submit. The whole
+        ``(image, workspace)`` pair drops out, not just that role: a pair one
+        role has to rebuild is not reusable for the roles that share it.
+
+        Returns an empty mapping (or ``None``) when *scheduler* has no workspace
+        support -- there is nothing to build.
+        """
+        authored_roles = (
+            app_or_role.roles if isinstance(app_or_role, AppDef) else [app_or_role]
+        )
+        with _overrides_detached(authored_roles) as detached_overrides:
+            roles = copy.deepcopy(authored_roles)
+        for role, overrides in zip(roles, detached_overrides):
+            role.overrides = overrides
+
+        with log_event("build_workspace", scheduler):
+            sched = self._scheduler(scheduler)
+            if not isinstance(sched, WorkspaceMixin):
+                return None if isinstance(app_or_role, Role) else {}
+            # one call, so roles sharing a workspace hit the shared build cache
+            sched.build_workspaces(roles, sched.run_opts().resolve(cfg or {}))
+
+        reusable: dict[tuple[str, Workspace], str] = {}
+        rebuilt: set[tuple[str, Workspace]] = set()
+        for authored, role in zip(authored_roles, roles, strict=True):
+            workspace = authored.workspace
+            if not workspace:
+                continue
+            if not _built_only_the_image(authored, role):
+                logger.warning(
+                    "role `%s` cannot reuse its build: the `%s` workspace builder"
+                    " changed more than `image`, so the workspace has to be rebuilt"
+                    " on each submit",
+                    authored.name,
+                    scheduler,
+                )
+                rebuilt.add((authored.image, workspace))
+                continue
+            reusable[(authored.image, workspace)] = role.image
+        for key in rebuilt:
+            reusable.pop(key, None)
+
+        if isinstance(app_or_role, Role):
+            workspace = app_or_role.workspace
+            return reusable.get((app_or_role.image, workspace)) if workspace else None
+        return reusable
+
     def dryrun(
         self,
         app: AppDef,
@@ -404,21 +550,8 @@ class Runner:
         # below never leak into the caller's AppDef (one AppDef can be
         # dry-run multiple times); the copy is returned as the AppDryRunInfo's
         # `app`.
-        #
-        # Role.overrides may already hold non-deepcopyable values (e.g. APF
-        # attaches an in-flight fbpkg Future before calling dryrun), so mirror
-        # the macros.Values.apply pattern: detach overrides, deepcopy, then
-        # attach the SAME dict object to both the original and the copy —
-        # sharing is the intended semantic: resolving an override through
-        # either owner benefits both.
-        detached_overrides = [role.overrides for role in app.roles]
-        for role in app.roles:
-            role.overrides = {}
-        try:
+        with _overrides_detached(app.roles) as detached_overrides:
             app_copy = copy.deepcopy(app)
-        finally:
-            for role, overrides in zip(app.roles, detached_overrides):
-                role.overrides = overrides
         for role_copy, overrides in zip(app_copy.roles, detached_overrides):
             role_copy.overrides = overrides
         app = app_copy

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import copy
+import dataclasses
 import datetime
 import os
 from contextlib import contextmanager
@@ -42,7 +43,7 @@ from torchx.specs import (
 from torchx.specs.finder import ComponentNotFoundException
 from torchx.test.fixtures import TestWithTmpDir
 from torchx.util.types import none_throws
-from torchx.workspace import WorkspaceMixin
+from torchx.workspace import pin_workspace_images, WorkspaceMixin
 
 GET_SCHEDULER_FACTORIES = "torchx.runner.api.get_scheduler_factories"
 
@@ -58,6 +59,97 @@ SESSION_NAME = "test_session"
 
 def get_full_path(name: str) -> str:
     return os.path.join(os.path.dirname(__file__), "resource", name)
+
+
+class _NoopScheduler(Scheduler[Mapping[str, CfgVal]]):
+    """Concrete `Scheduler` that schedules nothing; no workspace support."""
+
+    def schedule(self, dryrun_info: AppDryRunInfo) -> str:
+        return "app-id"
+
+    def _submit_dryrun(
+        self, app: AppDef, cfg: Mapping[str, CfgVal]
+    ) -> AppDryRunInfo[AppDef]:
+        return AppDryRunInfo(app, str)
+
+    def describe(self, app_id: str) -> DescribeAppResponse | None:
+        return None
+
+    def list(self, cfg: Mapping[str, CfgVal] | None = None) -> list[ListAppResponse]:
+        return []
+
+    def _cancel_existing(self, app_id: str) -> None:
+        pass
+
+
+class _BuildRecordingScheduler(WorkspaceMixin[None], _NoopScheduler):
+    """Appends each workspace it actually builds to *builds* -- cache hits are not recorded.
+
+    Caches on ``(image, workspace)``, as the real builders do.
+    """
+
+    def __init__(self, builds: list[str]) -> None:
+        super().__init__(backend="ignored", session_name="ignored")
+        self.builds = builds
+        self.built_roles: list[Role] = []
+
+    def caching_build_workspace_and_update_role(
+        self,
+        role: Role,
+        cfg: Mapping[str, CfgVal],
+        build_cache: dict[object, object],
+    ) -> None:
+        self.built_roles.append(role)
+        workspace = str(role.workspace)
+        key = (role.image, workspace)
+        if key not in build_cache:
+            self.builds.append(workspace)
+            build_cache[key] = f"built-{len(self.builds)}"
+        role.image = str(build_cache[key])
+
+
+class _EnvWritingScheduler(_BuildRecordingScheduler):
+    def caching_build_workspace_and_update_role(
+        self,
+        role: Role,
+        cfg: Mapping[str, CfgVal],
+        build_cache: dict[object, object],
+    ) -> None:
+        workspace = str(role.workspace)
+        super().caching_build_workspace_and_update_role(role, cfg, build_cache)
+        role.env["WORKSPACE_DIR"] = workspace
+
+
+@dataclasses.dataclass
+class _RoleWithExtraField(Role):
+    extra: str = ""
+
+
+class _ExtraFieldWritingScheduler(_BuildRecordingScheduler):
+    def caching_build_workspace_and_update_role(
+        self,
+        role: Role,
+        cfg: Mapping[str, CfgVal],
+        build_cache: dict[object, object],
+    ) -> None:
+        super().caching_build_workspace_and_update_role(role, cfg, build_cache)
+        assert isinstance(
+            role, _RoleWithExtraField
+        ), f"this scheduler only builds `_RoleWithExtraField`, got `{type(role)}`"
+        role.extra = "written-by-the-build"
+
+
+class _EnvWritingForOneRoleScheduler(_BuildRecordingScheduler):
+    def caching_build_workspace_and_update_role(
+        self,
+        role: Role,
+        cfg: Mapping[str, CfgVal],
+        build_cache: dict[object, object],
+    ) -> None:
+        workspace = str(role.workspace)
+        super().caching_build_workspace_and_update_role(role, cfg, build_cache)
+        if role.name == "b":
+            role.env["WORKSPACE_DIR"] = workspace
 
 
 @patch("torchx.runner.events.record")
@@ -641,6 +733,243 @@ class RunnerTest(TestWithTmpDir):
             self.assertEqual("//foo", roles[0].env["SRC_WORKSPACE"])
             self.assertEqual("bar_new", roles[1].image)
             self.assertEqual("//bar", roles[1].env["SRC_WORKSPACE"])
+
+    @staticmethod
+    def _workspace_runner(builds: list[str]) -> Runner:
+        return Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "builds-img": lambda session_name, **kwargs: _BuildRecordingScheduler(
+                    builds
+                ),
+                "writes-env": lambda session_name, **kwargs: _EnvWritingScheduler(
+                    builds
+                ),
+                "writes-env-for-b": lambda session_name, **kwargs: _EnvWritingForOneRoleScheduler(
+                    builds
+                ),
+                "writes-extra": lambda session_name, **kwargs: _ExtraFieldWritingScheduler(
+                    builds
+                ),
+                "no-workspace": lambda session_name, **kwargs: _NoopScheduler(
+                    backend="ignored", session_name="ignored"
+                ),
+            },
+        )
+
+    @staticmethod
+    def _role(name: str, image: str, workspace: str | None = None) -> Role:
+        return Role(
+            name=name,
+            image=image,
+            resource=resource.SMALL,
+            entrypoint="/bin/true",
+            workspace=Workspace.from_str(workspace) if workspace else None,
+        )
+
+    def test_build_workspace_builds_shared_workspace_once(self, _: MagicMock) -> None:
+        builds: list[str] = []
+        app = AppDef(
+            "ignored",
+            roles=[
+                self._role("a", "foo", "//shared"),
+                self._role("b", "foo", "//shared"),
+                self._role("c", "bar", "//other"),
+                self._role("d", "prebuilt"),
+            ],
+        )
+        with self._workspace_runner(builds) as runner:
+            images = runner.build_workspace(app, "builds-img")
+
+        self.assertEqual(["//shared", "//other"], builds)
+        self.assertEqual(
+            {
+                ("foo", Workspace.from_str("//shared")): "built-1",
+                ("bar", Workspace.from_str("//other")): "built-2",
+            },
+            images,
+        )
+
+    def test_build_workspace_keys_one_workspace_by_each_base_image(
+        self, _: MagicMock
+    ) -> None:
+        builds: list[str] = []
+        app = AppDef(
+            "ignored",
+            roles=[
+                self._role("a", "foo", "//shared"),
+                self._role("b", "bar", "//shared"),
+            ],
+        )
+        with self._workspace_runner(builds) as runner:
+            images = runner.build_workspace(app, "builds-img")
+
+        self.assertEqual(["//shared", "//shared"], builds)
+        self.assertEqual(
+            {
+                ("foo", Workspace.from_str("//shared")): "built-1",
+                ("bar", Workspace.from_str("//shared")): "built-2",
+            },
+            images,
+        )
+
+    def test_build_workspace_pins_each_base_image_to_its_own_build(
+        self, _: MagicMock
+    ) -> None:
+        with self._workspace_runner([]) as runner:
+            images = runner.build_workspace(
+                AppDef(
+                    "ignored",
+                    roles=[
+                        self._role("a", "foo", "//shared"),
+                        self._role("b", "bar", "//shared"),
+                    ],
+                ),
+                "builds-img",
+            )
+            other = AppDef(
+                "other",
+                roles=[
+                    self._role("c", "bar", "//shared"),
+                    self._role("d", "foo", "//shared"),
+                ],
+            )
+            pin_workspace_images(other, images)
+
+        self.assertEqual(["built-2", "built-1"], [r.image for r in other.roles])
+
+    def test_build_workspace_omits_a_build_that_wrote_beyond_the_image(
+        self, _: MagicMock
+    ) -> None:
+        app = AppDef("ignored", roles=[self._role("a", "foo", "//ws")])
+        with self._workspace_runner([]) as runner:
+            with self.assertLogs("torchx.runner.api", level="WARNING") as logs:
+                images = runner.build_workspace(app, "writes-env")
+            self.assertEqual({}, images)
+            self.assertIsNone(
+                runner.build_workspace(self._role("a", "foo", "//ws"), "writes-env")
+            )
+        self.assertIn("changed more than `image`", "".join(logs.output))
+
+    def test_build_workspace_omits_a_build_that_wrote_a_role_subclass_field(
+        self, _: MagicMock
+    ) -> None:
+        role = _RoleWithExtraField(
+            name="a",
+            image="foo",
+            resource=resource.SMALL,
+            entrypoint="/bin/true",
+            workspace=Workspace.from_str("//ws"),
+        )
+        with self._workspace_runner([]) as runner:
+            with self.assertLogs("torchx.runner.api", level="WARNING") as logs:
+                images = runner.build_workspace(
+                    AppDef("ignored", roles=[role]), "writes-extra"
+                )
+            self.assertEqual({}, images)
+        self.assertIn("changed more than `image`", "".join(logs.output))
+
+    def test_build_workspace_omitted_role_still_rebuilds_on_submit(
+        self, _: MagicMock
+    ) -> None:
+        builds: list[str] = []
+        with self._workspace_runner(builds) as runner:
+            images = runner.build_workspace(
+                AppDef("ignored", roles=[self._role("a", "foo", "//ws")]), "writes-env"
+            )
+            other = AppDef("other", roles=[self._role("b", "foo", "//ws")])
+            pin_workspace_images(other, images)
+
+            self.assertEqual(Workspace.from_str("//ws"), other.roles[0].workspace)
+            roles = runner.dryrun(other, "writes-env").request.roles
+
+        self.assertEqual("//ws", roles[0].env["WORKSPACE_DIR"])
+        self.assertEqual(["//ws", "//ws"], builds)
+
+    def test_build_workspace_omits_a_pair_one_of_its_roles_must_rebuild(
+        self, _: MagicMock
+    ) -> None:
+        app = AppDef(
+            "ignored",
+            roles=[self._role("a", "foo", "//ws"), self._role("b", "foo", "//ws")],
+        )
+        with self._workspace_runner([]) as runner:
+            with self.assertLogs("torchx.runner.api", level="WARNING") as logs:
+                images = runner.build_workspace(app, "writes-env-for-b")
+
+        self.assertEqual({}, images)
+        self.assertIn("role `b` cannot reuse its build", "".join(logs.output))
+
+    def test_build_workspace_does_not_mutate_caller(self, _: MagicMock) -> None:
+        app = AppDef("ignored", roles=[self._role("a", "foo", "//ws")])
+        with self._workspace_runner([]) as runner:
+            runner.build_workspace(app, "builds-img")
+
+        self.assertEqual("foo", app.roles[0].image)
+        self.assertEqual(Workspace.from_str("//ws"), app.roles[0].workspace)
+
+    def test_build_workspace_with_non_deepcopyable_overrides(
+        self, _: MagicMock
+    ) -> None:
+        """As in ``dryrun``: ``Role.overrides`` may hold values deepcopy chokes
+        on (an APF fbpkg Future), and the built copy must SHARE the dict."""
+        future: concurrent.futures.Future[str] = concurrent.futures.Future()
+        role = self._role("a", "foo", "//ws")
+        role.overrides = {"fbpkg": future}
+        app = AppDef("ignored", roles=[role])
+        sched = _BuildRecordingScheduler([])
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={"builds-img": lambda session_name, **kwargs: sched},
+        ) as runner:
+            images = runner.build_workspace(app, "builds-img")
+
+        self.assertEqual({("foo", Workspace.from_str("//ws")): "built-1"}, images)
+        self.assertIs(role.overrides, sched.built_roles[0].overrides)
+        self.assertIsNot(role, sched.built_roles[0])
+
+    def test_build_workspace_single_role(self, _: MagicMock) -> None:
+        with self._workspace_runner([]) as runner:
+            self.assertEqual(
+                "built-1",
+                runner.build_workspace(self._role("a", "foo", "//ws"), "builds-img"),
+            )
+            self.assertIsNone(
+                runner.build_workspace(self._role("a", "prebuilt"), "builds-img")
+            )
+
+    def test_build_workspace_scheduler_without_workspace_support(
+        self, _: MagicMock
+    ) -> None:
+        app = AppDef("ignored", roles=[self._role("a", "foo", "//ws")])
+        with self._workspace_runner([]) as runner:
+            self.assertEqual({}, runner.build_workspace(app, "no-workspace"))
+            self.assertIsNone(
+                runner.build_workspace(self._role("a", "foo", "//ws"), "no-workspace")
+            )
+
+    def test_build_workspace_pinned_onto_another_appdef_skips_rebuild(
+        self, _: MagicMock
+    ) -> None:
+        builds: list[str] = []
+        with self._workspace_runner(builds) as runner:
+            images = runner.build_workspace(
+                AppDef("ignored", roles=[self._role("a", "foo", "//ws")]),
+                "builds-img",
+            )
+            other = AppDef(
+                "other",
+                roles=[self._role("b", "foo", "//ws"), self._role("c", "prebuilt")],
+            )
+            pin_workspace_images(other, images)
+
+            self.assertEqual(["//ws"], builds)
+            self.assertEqual("built-1", other.roles[0].image)
+            self.assertIsNone(other.roles[0].workspace)
+            self.assertEqual("prebuilt", other.roles[1].image)
+
+            runner.dryrun(other, "builds-img")
+            self.assertEqual(["//ws"], builds, "pinned role must not rebuild")
 
     def test_describe(self, _: MagicMock) -> None:
         with self.get_runner() as runner:

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -395,7 +395,19 @@ class Scheduler(abc.ABC, Generic[T]):
         cfg: T,
         workspace: str | Workspace | None = None,
     ) -> str:
-        """Submits an app directly. Prefer :py:meth:`~torchx.runner.api.Runner.run` for production use."""
+        """Submits an app directly. Prefer :py:meth:`~torchx.runner.api.Runner.run` for production use.
+
+        **Mutates** *app*: unlike :py:meth:`~torchx.runner.api.Runner.run`, no copy
+        is taken, so every write lands on the caller's own object. Passing
+        *workspace* sets ``app.roles[0].workspace`` and repoints
+        ``app.roles[*].image`` at the build; without it nothing is built, and a
+        role carrying its own :py:attr:`~torchx.specs.Role.workspace` reaches
+        :py:meth:`_submit_dryrun` unbuilt.
+
+        Raises:
+            ValueError: *workspace* was passed but this scheduler is not a
+                :py:class:`~torchx.workspace.WorkspaceMixin`.
+        """
         # pyre-fixme: Generic cfg type passed to resolve
         resolved_cfg = self.run_opts().resolve(cfg)
         if workspace:
@@ -420,7 +432,19 @@ class Scheduler(abc.ABC, Generic[T]):
         raise NotImplementedError()
 
     def submit_dryrun(self, app: AppDef, cfg: T) -> AppDryRunInfo:
-        """Returns the scheduler request without submitting."""
+        """Returns the scheduler request without submitting.
+
+        **No copy is taken**: the returned
+        :py:attr:`~torchx.specs.AppDryRunInfo.app` *is* the *app* passed in, and
+        :py:meth:`_submit_dryrun` and each role's ``pre_proc`` may mutate it.
+        Callers wanting their :py:class:`~torchx.specs.AppDef` left alone should
+        go through :py:meth:`~torchx.runner.api.Runner.dryrun`, which copies
+        first.
+
+        :py:attr:`~torchx.specs.AppDryRunInfo.cfg` is *cfg* with this
+        scheduler's :py:meth:`run_opts` defaults applied, so it is not
+        necessarily the mapping that was passed in.
+        """
         # pyre-fixme: Generic cfg type passed to resolve
         resolved_cfg = self.run_opts().resolve(cfg)
         # pyre-fixme: _submit_dryrun takes Generic type for resolved_cfg
@@ -435,6 +459,22 @@ class Scheduler(abc.ABC, Generic[T]):
 
     @abc.abstractmethod
     def _submit_dryrun(self, app: AppDef, cfg: T) -> AppDryRunInfo:
+        """Renders *app* into this backend's submit request.
+
+        Implementations receive *cfg* already resolved against
+        :py:meth:`run_opts` and read ``role.image`` as final -- building a
+        role's workspace is never their job. Reached through
+        :py:meth:`~torchx.runner.api.Runner.dryrun`, or through
+        :py:meth:`submit` with a *workspace*, that build has already happened
+        and ``role.image`` points at its result; a caller who invokes
+        :py:meth:`submit_dryrun` directly can still hand over roles whose
+        ``workspace`` was never built.
+
+        Mutating *app* is permitted (the caller owns no copy) but discouraged:
+        prefer rendering into the returned
+        :py:class:`~torchx.specs.AppDryRunInfo`. Do not set its ``app``/``cfg``
+        attributes -- :py:meth:`submit_dryrun` does that.
+        """
         raise NotImplementedError()
 
     def run_opts(self) -> runopts:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1008,11 +1008,20 @@ class AppDryRunInfo(Generic[T]):
     Attributes:
         request: The scheduler-specific submit request.
         app: The resolved :py:class:`AppDef` ``request`` was rendered from.
-            ``None`` until set by :py:meth:`Runner.dryrun
-            <torchx.runner.Runner.dryrun>` or :py:meth:`Scheduler.submit_dryrun
-            <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+            ``None`` until set by :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>`. What it carries
+            depends on the entry point: via :py:meth:`Runner.dryrun
+            <torchx.runner.Runner.dryrun>` it is a private copy, patched with
+            the built workspace image and the injected ``TORCHX_*`` env vars,
+            leaving the caller's own untouched; via
+            :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>` directly it is the
+            very object passed in, with neither step applied.
         cfg: The resolved run config (defaults applied). Empty until set
-            alongside ``app``.
+            alongside ``app``. Not a copy either: it is the same mapping the
+            scheduler was handed, so mutating it in place reaches whatever the
+            scheduler retained. The ``Mapping`` annotation is the only thing
+            saying not to.
     """
 
     def __init__(self, request: T, fmt: Callable[[T], str]) -> None:

--- a/torchx/workspace/__init__.py
+++ b/torchx/workspace/__init__.py
@@ -22,4 +22,8 @@ Example workspace paths:
     * ``memory://foo-bar/`` an in-memory workspace for notebook/programmatic usage
 """
 
-from torchx.workspace.api import walk_workspace, WorkspaceMixin  # noqa: F401
+from torchx.workspace.api import (  # noqa: F401
+    pin_workspace_images,
+    walk_workspace,
+    WorkspaceMixin,
+)

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -186,6 +186,29 @@ class WorkspaceMixin(abc.ABC, Generic[T]):
         raise NotImplementedError("push is not implemented")
 
 
+def pin_workspace_images(
+    app: AppDef, images: Mapping[tuple[str, Workspace], str]
+) -> None:
+    """Points each role at its already-built image so submitting *app* skips the rebuild.
+
+    Pairs with :py:meth:`~torchx.runner.Runner.build_workspace`, whose return
+    value *images* is. Mutates *app*: a pinned role gets ``image`` set and
+    ``workspace`` cleared, which is what makes the rebuild a no-op.
+
+    A role matches on its whole ``(image, workspace)`` pair, since that is what
+    the build ran on: one sharing only the workspace is a different build and is
+    left alone, as is a role with no workspace (it arrived with a pre-built image
+    that must not be clobbered) or one whose pair nobody built.
+    """
+    for role in app.roles:
+        if not role.workspace:
+            continue
+        image = images.get((role.image, role.workspace))
+        if image is not None:
+            role.image = image
+            role.workspace = None
+
+
 def _ignore(s: str, patterns: Iterable[str]) -> tuple[int, bool]:
     last_matching_pattern = -1
     match = False

--- a/torchx/workspace/api.py
+++ b/torchx/workspace/api.py
@@ -99,7 +99,14 @@ class WorkspaceMixin(abc.ABC, Generic[T]):
 
         .. important::
             Mutates the passed *roles*. May also add env vars (e.g. ``WORKSPACE_DIR``)
-            to ``role.env``.
+            to ``role.env``. ``role.workspace`` is left set, so a role that has
+            been through this method is not distinguishable by inspection from
+            one that has not -- compare ``role.image`` instead.
+
+        Called by :py:meth:`~torchx.runner.api.Runner.dryrun` with the roles of
+        its private copy, so the caller's :py:class:`~torchx.specs.AppDef` is
+        unaffected there; :py:meth:`~torchx.schedulers.api.Scheduler.submit`
+        passes the caller's own roles.
         """
 
         build_cache: dict[object, object] = {}

--- a/torchx/workspace/test/api_test.py
+++ b/torchx/workspace/test/api_test.py
@@ -7,12 +7,13 @@
 # pyre-strict
 
 import shutil
+import unittest
 from pathlib import Path
 from typing import Mapping
 
-from torchx.specs import CfgVal, Role, Workspace
+from torchx.specs import AppDef, CfgVal, Role, Workspace
 from torchx.test.fixtures import TestWithTmpDir
-from torchx.workspace.api import WorkspaceMixin
+from torchx.workspace.api import pin_workspace_images, WorkspaceMixin
 from typing_extensions import override
 
 IGNORED = "__IGNORED__"
@@ -201,3 +202,43 @@ class CachingWorkspaceTest(TestWithTmpDir):
                 "baz:1": merged_workspace2,
             },
         )
+
+
+class PinWorkspaceImagesTest(unittest.TestCase):
+    @staticmethod
+    def _role(name: str, image: str, workspace: Workspace | None) -> Role:
+        return Role(name=name, image=image, workspace=workspace)
+
+    def test_pins_and_clears_workspace(self) -> None:
+        ws = Workspace.from_str("//ws")
+        app = AppDef("app", roles=[self._role("a", "unbuilt", ws)])
+
+        pin_workspace_images(app, {("unbuilt", ws): "built:abc"})
+
+        self.assertEqual("built:abc", app.roles[0].image)
+        self.assertIsNone(app.roles[0].workspace)
+
+    def test_leaves_prebuilt_and_unknown_workspaces_alone(self) -> None:
+        known, unknown = Workspace.from_str("//known"), Workspace.from_str("//unknown")
+        app = AppDef(
+            "app",
+            roles=[
+                self._role("prebuilt", "docker.io/img:1", None),
+                self._role("unknown", "unbuilt", unknown),
+            ],
+        )
+
+        pin_workspace_images(app, {("unbuilt", known): "built:abc"})
+
+        self.assertEqual("docker.io/img:1", app.roles[0].image)
+        self.assertEqual("unbuilt", app.roles[1].image)
+        self.assertEqual(unknown, app.roles[1].workspace)
+
+    def test_leaves_the_same_workspace_on_another_base_image_alone(self) -> None:
+        ws = Workspace.from_str("//ws")
+        app = AppDef("app", roles=[self._role("a", "other-base", ws)])
+
+        pin_workspace_images(app, {("base", ws): "built:abc"})
+
+        self.assertEqual("other-base", app.roles[0].image)
+        self.assertEqual(ws, app.roles[0].workspace)


### PR DESCRIPTION
Summary:

Building a workspace happens only inside `runner.run()`/`dryrun()`, so submitting
the same workspace as N `AppDef`s (per region, per trial) builds it N times.
There was no public way to build it once:

```lang=python
images = runner.build_workspace(app, "kubernetes", cfg)  # built once, here

for app in per_region_apps:              # same workspace, different AppDefs
    pin_workspace_images(app, images)    # image set, role.workspace cleared
    runner.run(app, "kubernetes", cfg)   # nothing left to build
```

The result is keyed by `(image, workspace)`, not by role name, so it pins onto a
*different* `AppDef`. The base image is half the key because a build installs the
workspace *into* it: one workspace on two images is two builds. A role whose
build wrote beyond `image` -- some builders set `env` -- is omitted with a
warning and rebuilds on submit, since pinning cannot replay those writes. Neither
overload mutates its argument.

`dryrun`'s inline workaround for `Role.overrides` holding values `deepcopy`
chokes on (APF attaches an in-flight fbpkg Future) is now a module-level
`_overrides_detached`. `build_workspace` copies the same roles, so a plain
`copy.deepcopy` there would raise on the same input.

Differential Revision: D116720556
