### PR TITLE
(test)[torchx][cli] Branch-coverage tests for cmd_run (#1404)

### DIFF
--- a/torchx/cli/test/cmd_run_test.py
+++ b/torchx/cli/test/cmd_run_test.py
@@ -10,9 +10,11 @@
 import argparse
 import dataclasses
 import io
+import json
 import os
 import shutil
 import signal
+import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
@@ -25,13 +27,14 @@ from torchx.cli.cmd_run import (
     _parse_component_name_and_args,
     CmdBuiltins,
     CmdRun,
+    LOCAL_SCHEDULER_WARNING_MSG,
     torchx_run_args_from_argparse,
     torchx_run_args_from_json,
     TorchXRunArgs,
 )
 from torchx.schedulers.local_scheduler import SignalException
 from torchx.settings import ENV_TORCHXCONFIG
-from torchx.specs import AppDryRunInfo, CfgVal
+from torchx.specs import AppDryRunInfo, AppState, CfgVal
 
 
 @contextmanager
@@ -440,6 +443,176 @@ component = custom.echo
         args = self.parser.parse_args(["--stdin", "--scheduler", default_scheduler])
         # Should not raise any exception since it's the same as default
         self.cmd_run.verify_no_extra_args(args)
+
+    def test_run_inner_local_scheduler_warns_deprecation(self) -> None:
+        runner = MagicMock()
+        dryrun_info_stub = AppDryRunInfo("req", lambda x: x)
+        dryrun_info_stub._app = dataclasses.make_dataclass("T", [])()
+        runner.dryrun_component.return_value = dryrun_info_stub
+        run_args = TorchXRunArgs(
+            component_name="utils.echo",
+            scheduler="local",
+            scheduler_args={},
+            dryrun=True,
+        )
+
+        with patch("torchx.cli.cmd_run.config.apply"):
+            with self.assertLogs("torchx.cli.cmd_run", level="WARNING") as logs:
+                self.cmd_run._run_inner(runner, run_args)
+        self.assertTrue(
+            any(LOCAL_SCHEDULER_WARNING_MSG in line for line in logs.output),
+            msg="`-s local` must warn that the `local` scheduler is deprecated",
+        )
+
+    def test_run_inner_remote_scheduler_logs_status_and_waits(self) -> None:
+        runner = MagicMock()
+        runner.run_component.return_value = "kubernetes://session/app_id"
+        runner.status.return_value.format.return_value = "app status"
+        run_args = TorchXRunArgs(
+            component_name="utils.echo",
+            scheduler="kubernetes",
+            scheduler_args={},
+            wait=True,
+            tee_logs=True,
+        )
+
+        with patch.object(self.cmd_run, "_wait_and_exit") as wait_mock:
+            with self.assertLogs("torchx.cli.cmd_run", level="INFO") as logs:
+                self.cmd_run._run_inner(runner, run_args)
+        self.assertTrue(
+            any("app status" in line for line in logs.output),
+            msg="the status returned by the scheduler must be logged on submit",
+        )
+        wait_mock.assert_called_once_with(
+            runner, "kubernetes://session/app_id", log=False, tee_logs=True
+        )
+
+    def test_run_inner_remote_scheduler_none_status_skips_status_log(self) -> None:
+        runner = MagicMock()
+        runner.run_component.return_value = "kubernetes://session/app_id"
+        runner.status.return_value = None
+        run_args = TorchXRunArgs(
+            component_name="utils.echo",
+            scheduler="kubernetes",
+            scheduler_args={},
+        )
+
+        with patch.object(self.cmd_run, "_wait_and_exit") as wait_mock:
+            with self.assertLogs("torchx.cli.cmd_run", level="INFO") as logs:
+                self.cmd_run._run_inner(runner, run_args)
+        self.assertEqual(
+            1,
+            len(logs.output),
+            msg="a None status must skip the status log; only the launched-app"
+            " line may be emitted",
+        )
+        self.assertIn("launched app", logs.output[0])
+        wait_mock.assert_not_called()
+
+    def test_get_torchx_stdin_args_without_stdin_flag_returns_none(self) -> None:
+        args = self.parser.parse_args(["--scheduler", "local_cwd", "utils.echo"])
+        self.assertIsNone(
+            self.cmd_run._get_torchx_stdin_args(args),
+            msg="without --stdin no stdin payload may be read",
+        )
+
+    def test_get_torchx_stdin_args_reads_stdin_once_and_caches(self) -> None:
+        args = self.parser.parse_args(["--stdin"])
+        with patch("sys.stdin", io.StringIO('{"scheduler": "local_cwd"}')):
+            first = self.cmd_run._get_torchx_stdin_args(args)
+        self.assertEqual({"scheduler": "local_cwd"}, first)
+
+        with patch("sys.stdin", io.StringIO("")):
+            second = self.cmd_run._get_torchx_stdin_args(args)
+        self.assertIs(
+            first,
+            second,
+            msg="repeated calls must serve the cached payload, not re-read stdin"
+            " (re-reading the now-empty stdin would exit(1))",
+        )
+
+    def test_torchx_json_from_stdin_dryrun_flag_injected_into_payload(self) -> None:
+        args = self.parser.parse_args(["--stdin", "--dryrun"])
+        with patch("sys.stdin", io.StringIO('{"scheduler": "local_cwd"}')):
+            data = self.cmd_run.torchx_json_from_stdin(args)
+        self.assertEqual(
+            True,
+            data["dryrun"],
+            msg="--dryrun on the CLI must override the stdin payload's dryrun",
+        )
+
+    def test_torchx_json_from_stdin_without_args_leaves_payload_unmodified(
+        self,
+    ) -> None:
+        with patch("sys.stdin", io.StringIO('{"scheduler": "local_cwd"}')):
+            data = self.cmd_run.torchx_json_from_stdin()
+        self.assertEqual(
+            {"scheduler": "local_cwd"},
+            data,
+            msg="without argparse args the stdin payload must pass through untouched",
+        )
+
+    def test_run_dispatches_stdin_payload(self) -> None:
+        args = self.parser.parse_args(["--stdin"])
+        runner = MagicMock()
+        payload = {
+            "scheduler": "local_cwd",
+            "scheduler_args": {},
+            "component_name": "utils.echo",
+        }
+        with patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            with patch.object(self.cmd_run, "_run_from_stdin_args") as stdin_run_mock:
+                self.cmd_run._run(runner, args)
+        stdin_run_mock.assert_called_once_with(runner, payload)
+
+    def test_wait_and_exit_unknown_status_raises(self) -> None:
+        runner = MagicMock()
+        runner.wait.return_value = None
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "unknown status",
+            msg="a None from runner.wait must fail loudly, not exit 0",
+        ):
+            self.cmd_run._wait_and_exit(
+                runner, "kubernetes://session/app_id", log=False
+            )
+
+    def test_wait_and_exit_failed_app_exits_nonzero(self) -> None:
+        runner = MagicMock()
+        runner.wait.return_value.state = AppState.FAILED
+        with self.assertRaises(SystemExit) as cm:
+            self.cmd_run._wait_and_exit(
+                runner, "kubernetes://session/app_id", log=False
+            )
+        self.assertEqual(
+            1,
+            cm.exception.code,
+            msg="a non-SUCCEEDED terminal state must exit 1 so callers see the failure",
+        )
+
+    def test_start_log_thread_tee_logs_enabled(self) -> None:
+        runner = MagicMock()
+        tee_thread = MagicMock()
+        with patch(
+            "torchx.cli.cmd_run.tee_logs", return_value=tee_thread
+        ) as tee_logs_mock:
+            returned = self.cmd_run._start_log_thread(
+                runner, "kubernetes://session/app_id", tee_logs_enabled=True
+            )
+        tee_thread.start.assert_called_once()
+        self.assertIs(
+            tee_thread,
+            returned,
+            msg="--tee_logs must stream through tee_logs, not plain get_logs",
+        )
+        kwargs = tee_logs_mock.call_args.kwargs
+        self.assertIs(sys.stderr, kwargs["dst"])
+        self.assertEqual("kubernetes://session/app_id", kwargs["app_handle"])
+        self.assertIs(runner, kwargs["runner"])
+        self.assertTrue(
+            kwargs["should_tail"],
+            msg="the CLI tee path must tail until the job stops producing logs",
+        )
 
     def test_verify_no_extra_args_stdin_with_default_workspace(self) -> None:
         """Test that using default workspace with stdin doesn't conflict."""

--- a/torchx/util/test/log_tee_helpers_test.py
+++ b/torchx/util/test/log_tee_helpers_test.py
@@ -7,11 +7,228 @@
 # pyre-strict
 
 import io
+import threading
 import unittest
+from collections.abc import Iterator
+from queue import Queue
+from typing import NoReturn
 from unittest.mock import MagicMock, patch
 
 from torchx.schedulers.api import Stream
-from torchx.util.log_tee_helpers import tee_logs
+from torchx.specs.api import AppDef, Role
+from torchx.util.log_tee_helpers import (
+    _print_log_lines_for_role_replica,
+    _start_threads_to_monitor_role_replicas,
+    tee_logs,
+)
+
+
+class PrintLogLinesForRoleReplicaTest(unittest.TestCase):
+    def _print(
+        self,
+        lines: list[str],
+        colorize: bool,
+        exceptions: "Queue[Exception]",
+    ) -> tuple[io.StringIO, MagicMock]:
+        dst = io.StringIO()
+        runner = MagicMock()
+        runner.log_lines.return_value = iter(lines)
+        _print_log_lines_for_role_replica(
+            dst=dst,
+            app_handle="local://test_session/test_app",
+            regex=None,
+            runner=runner,
+            which_role="worker",
+            which_replica=1,
+            exceptions=exceptions,
+            should_tail=False,
+            streams=None,
+            colorize=colorize,
+        )
+        return dst, runner
+
+    def test_prefixes_every_line_with_role_and_replica(self) -> None:
+        exceptions: "Queue[Exception]" = Queue()
+        dst, _ = self._print(
+            ["alpha\n", "beta\n"], colorize=False, exceptions=exceptions
+        )
+        self.assertEqual(
+            "worker/1 alpha\nworker/1 beta\n",
+            dst.getvalue(),
+            msg="every log line must carry a plain `role/replica ` prefix when colorize is off",
+        )
+
+    def test_colorize_wraps_prefix_in_ansi_green(self) -> None:
+        exceptions: "Queue[Exception]" = Queue()
+        dst, _ = self._print(["alpha\n"], colorize=True, exceptions=exceptions)
+        self.assertEqual(
+            "\033[32mworker/1\033[0m alpha\n",
+            dst.getvalue(),
+            msg="colorize=True must wrap only the `role/replica` prefix in green ANSI codes",
+        )
+
+    def test_empty_log_stream_writes_nothing(self) -> None:
+        exceptions: "Queue[Exception]" = Queue()
+        dst, _ = self._print([], colorize=False, exceptions=exceptions)
+        self.assertEqual(
+            "",
+            dst.getvalue(),
+            msg="a replica with no log lines must produce no output (not even a bare prefix)",
+        )
+
+    def test_log_lines_error_is_recorded_and_reraised(self) -> None:
+        exceptions: "Queue[Exception]" = Queue()
+        dst = io.StringIO()
+        runner = MagicMock()
+        error = RuntimeError("stream broke")
+        runner.log_lines.side_effect = error
+        with self.assertRaises(RuntimeError):
+            _print_log_lines_for_role_replica(
+                dst=dst,
+                app_handle="local://test_session/test_app",
+                regex=None,
+                runner=runner,
+                which_role="worker",
+                which_replica=0,
+                exceptions=exceptions,
+                should_tail=False,
+                streams=None,
+                colorize=False,
+            )
+        self.assertIs(
+            error,
+            exceptions.get_nowait(),
+            msg="the raised exception must also be queued so the parent thread can see it",
+        )
+
+
+class _InlineThread(threading.Thread):
+    def start(self) -> None:
+        self.run()
+
+    def join(self, timeout: float | None = None) -> None:
+        pass
+
+
+class StartThreadsToMonitorRoleReplicasTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = AppDef(
+            name="test_app",
+            roles=[
+                Role(name="trainer", image="/tmp", num_replicas=2),
+                Role(name="reader", image="/tmp", num_replicas=1),
+            ],
+        )
+        self.runner = MagicMock()
+        self.runner.describe.return_value = self.app
+
+    def test_tees_logs_of_every_role_replica(self) -> None:
+        def fake_log_lines(
+            app_handle: str,
+            role_name: str,
+            replica_id: int,
+            regex: str | None,
+            should_tail: bool = False,
+            streams: "Stream | None" = None,
+        ) -> Iterator[str]:
+            return iter([f"hello from {role_name}/{replica_id}\n"])
+
+        self.runner.log_lines.side_effect = fake_log_lines
+        dst = io.StringIO()
+        with patch("torchx.util.log_tee_helpers.threading.Thread", new=_InlineThread):
+            _start_threads_to_monitor_role_replicas(
+                dst=dst,
+                app_handle="local://test_session/test_app",
+                regex="foo.*",
+                runner=self.runner,
+                should_tail=True,
+                streams=Stream.STDERR,
+            )
+        self.assertEqual(
+            [
+                "reader/0 hello from reader/0",
+                "trainer/0 hello from trainer/0",
+                "trainer/1 hello from trainer/1",
+            ],
+            sorted(dst.getvalue().splitlines()),
+            msg="one prefixed line per (role, replica) pair must reach the destination",
+        )
+        self.runner.log_lines.assert_any_call(
+            "local://test_session/test_app",
+            "trainer",
+            0,
+            "foo.*",
+            should_tail=True,
+            streams=Stream.STDERR,
+        )
+
+    def test_unknown_role_raises_with_valid_role_names(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            r"nonexistent is not a valid role name.*trainer.*reader",
+            msg="filtering to an unknown role must fail fast naming the valid roles",
+        ):
+            _start_threads_to_monitor_role_replicas(
+                dst=io.StringIO(),
+                app_handle="local://test_session/test_app",
+                regex=None,
+                runner=self.runner,
+                which_role="nonexistent",
+            )
+        self.runner.log_lines.assert_not_called()
+
+    def test_single_replica_error_propagates_without_extra_logging(self) -> None:
+        self.runner.log_lines.side_effect = RuntimeError("reader stream broke")
+        with patch("threading.excepthook"):
+            with self.assertRaisesRegex(RuntimeError, "reader stream broke"):
+                with self.assertNoLogs("torchx.util.log_tee_helpers", level="ERROR"):
+                    _start_threads_to_monitor_role_replicas(
+                        dst=io.StringIO(),
+                        app_handle="local://test_session/test_app",
+                        regex=None,
+                        runner=self.runner,
+                        which_role="reader",
+                    )
+
+    def test_first_replica_error_raised_rest_logged(self) -> None:
+        errors: dict[int, RuntimeError] = {
+            0: RuntimeError("replica 0 broke"),
+            1: RuntimeError("replica 1 broke"),
+        }
+
+        def fail_log_lines(
+            app_handle: str,
+            role_name: str,
+            replica_id: int,
+            regex: str | None,
+            should_tail: bool = False,
+            streams: "Stream | None" = None,
+        ) -> NoReturn:
+            raise errors[replica_id]
+
+        self.runner.log_lines.side_effect = fail_log_lines
+        with patch("threading.excepthook"):
+            with self.assertLogs("torchx.util.log_tee_helpers", level="ERROR") as logs:
+                with self.assertRaises(RuntimeError) as cm:
+                    _start_threads_to_monitor_role_replicas(
+                        dst=io.StringIO(),
+                        app_handle="local://test_session/test_app",
+                        regex=None,
+                        runner=self.runner,
+                        which_role="trainer",
+                    )
+        raised = str(cm.exception)
+        logged = [r.getMessage() for r in logs.records]
+        self.assertEqual(
+            1,
+            len(logged),
+            msg="with 2 failing replicas exactly one exception is logged (the other is raised)",
+        )
+        self.assertEqual(
+            {"replica 0 broke", "replica 1 broke"},
+            {raised, logged[0]},
+            msg="every replica failure must surface: one raised, all others logged",
+        )
 
 
 class TeeLogsTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

Pins the untested control-flow contracts of `torchx run` (worst-covered CLI file, 20 uncovered branches):

- `-s local` warns it is deprecated
- non-local submit: status is logged when the scheduler returns one; `_wait_and_exit` runs iff `--wait`/`--log`
- stdin mode: the JSON payload is read once and cached (a re-read would hit exhausted stdin), CLI `--dryrun` overrides the payload's, and a dict payload dispatches to `_run_from_stdin_args`
- `_wait_and_exit`: a `None` status raises instead of exiting 0; a non-`SUCCEEDED` terminal state exits 1 without joining a log thread when `--log` is off
- `--tee_logs` streams through `tee_logs(should_tail=True)` to stderr, not plain `get_logs`

`torchx/cli/cmd_run.py` coverage: **branch 71.4% (50/70) → 98.6% (69/70)**, line 85.5% → 95.5%. The one remaining arc (`_run`'s `stdin_data_json is None` false-exit) is defensively dead: `_get_torchx_stdin_args` cannot return `None` once `args.stdin` is set.

Differential Revision: D116750891
