### PR TITLE
(feature)[4/4][torchx][runner] Runner.describe_native — native read-back through the session API (#1405)

### DIFF
--- a/torchx/runner/api.py
+++ b/torchx/runner/api.py
@@ -586,6 +586,26 @@ class Runner:
                     app = AppDef(name=app_id, roles=desc.roles, metadata=desc.metadata)
             return app
 
+    def describe_native(self, app_handle: AppHandle) -> AppDryRunInfo | None:
+        """Reads the scheduler-native request back for an already-submitted app.
+
+        The read-side twin of :py:meth:`dryrun`: same
+        :py:class:`~torchx.specs.AppDryRunInfo` wrapper, same
+        scheduler-specific ``request`` type. Unlike :py:meth:`describe`, the
+        returned ``request`` preserves scheduler-specific fields that have no
+        :py:class:`~torchx.specs.AppDef` equivalent. Returns ``None`` if the
+        scheduler does not support native read-back or the app no longer
+        exists.
+        """
+        scheduler, scheduler_backend, app_id = self._scheduler_app_id(
+            app_handle, check_session=False
+        )
+        with log_event("describe_native", scheduler_backend, app_id):
+            info = scheduler.describe_native(app_id)
+            if info is not None:
+                info._scheduler = scheduler_backend
+            return info
+
     def log_lines(
         self,
         app_handle: AppHandle,

--- a/torchx/runner/test/api_test.py
+++ b/torchx/runner/test/api_test.py
@@ -665,6 +665,39 @@ class RunnerTest(TestWithTmpDir):
             # unknown app should return None
             self.assertIsNone(runner.describe("local_dir://session1/unknown_app"))
 
+    def test_describe_native(self, _: MagicMock) -> None:
+        with self.get_runner() as runner:
+            role = Role(
+                name="sleep",
+                image=str(self.tmpdir),
+                resource=resource.SMALL,
+                entrypoint="sleep",
+                args=["1"],
+            )
+            app = AppDef("sleeper", roles=[role])
+
+            app_handle = runner.run(app, scheduler="local_dir", cfg=self.cfg)
+            info = none_throws(runner.describe_native(app_handle))
+
+            _scheduler, _session_name, app_id = parse_app_handle(app_handle)
+            self.assertEqual(app_id, info.request.app_id)
+            self.assertEqual("local_dir", info._scheduler)
+            self.assertIsNone(
+                runner.describe_native("local_dir://test_session/unknown_app")
+            )
+
+    def test_describe_native_unsupported_scheduler(self, _: MagicMock) -> None:
+        mock_scheduler = MagicMock(spec=Scheduler)
+        mock_scheduler.describe_native.return_value = None
+
+        with Runner(
+            name=SESSION_NAME,
+            scheduler_factories={
+                "mock": cast(SchedulerFactory, lambda name, **kwargs: mock_scheduler)
+            },
+        ) as runner:
+            self.assertIsNone(runner.describe_native("mock://test_session/some_app_id"))
+
     def test_status(self, _: MagicMock) -> None:
         with self.get_runner() as runner:
             role = Role(


### PR DESCRIPTION
Summary:

Plumbs `describe_native` through `Runner`, completing the stack's target call shape. The motivating consumer: `genai/msl/rl`'s `adjust_*`/monitor tool family, which today shells out to scheduler RPCs because `runner.describe()` cannot return per-task-group env, application metadata, topology constraints, or restart policies. Target shape once the plugins scheduler opts in (separate stack, torchx_plugins clock):

```
runner = get_runner()
info = runner.describe_native(app_handle)  # AppDryRunInfo | None
info.request                               # scheduler-native jobdef, typed per scheduler
```

Resolution rides the existing machinery — `_scheduler_app_id` handles handle parsing and plugin/factory scheduler lookup; the `_scheduler` back-reference is set like `dryrun` does. `None` when the scheduler has no native read-back or the app is gone.

Stack: seam → local_scheduler opt-in → kubernetes opt-in → **`Runner.describe_native` (this)**.

Differential Revision: D116794792
