### PR TITLE
(feature)[2/4][torchx][schedulers] local_scheduler: retain the scheduled request for describe_native

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -452,6 +452,23 @@ class Scheduler(abc.ABC, Generic[T]):
         """Returns app description, or ``None`` if it no longer exists."""
         raise NotImplementedError()
 
+    def describe_native(self, app_id: str) -> Optional[AppDryRunInfo]:
+        """Returns the scheduler-native request of an already-submitted app.
+
+        The read-side twin of :py:meth:`submit_dryrun`: reads the request back
+        from the scheduler, wrapped in the same
+        :py:class:`~torchx.specs.AppDryRunInfo` (same scheduler-specific
+        ``request`` type). Unlike :py:meth:`describe`, which lossily maps the
+        job description onto :py:class:`~torchx.specs.AppDef`, the returned
+        ``request`` preserves scheduler-specific fields with no ``AppDef``
+        equivalent. The ``app``/``cfg`` back-references are populated only
+        where the scheduler retains them.
+
+        Returns ``None`` if this scheduler does not implement native read-back
+        (the default) or if the app no longer exists.
+        """
+        return None
+
     @abc.abstractmethod
     def list(self, cfg: Mapping[str, CfgVal] | None = None) -> List[ListAppResponse]:
         """Lists jobs on this scheduler."""

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -356,7 +356,12 @@ class _LocalAppDef:
     process and has a pid.
     """
 
-    def __init__(self, id: str, log_dir: str) -> None:
+    def __init__(
+        self,
+        id: str,
+        log_dir: str,
+        dryrun_info: "AppDryRunInfo[PopenRequest] | None" = None,
+    ) -> None:
         self.id = id
         # opts.log_dir/<session_name>/<app_id> or /tmp/torchx/<session_name>/<app_id>
         self.log_dir = log_dir
@@ -365,6 +370,7 @@ class _LocalAppDef:
         self.state: AppState = AppState.PENDING
         # time (in seconds since epoch) when the last set_state method() was called
         self.last_updated: float = -1
+        self.dryrun_info = dryrun_info
 
     def add_replica(self, role_name: str, replica: _LocalReplica) -> None:
         procs = self.role_replicas.setdefault(role_name, [])
@@ -807,7 +813,7 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
         ), "no app_id collisions expected since uuid4 suffix is used"
 
         os.makedirs(app_log_dir)
-        local_app = _LocalAppDef(app_id, app_log_dir)
+        local_app = _LocalAppDef(app_id, app_log_dir, dryrun_info)
 
         for role_name in request.role_params.keys():
             role_params = request.role_params[role_name]
@@ -1067,6 +1073,12 @@ Reduce requested GPU resources or use a host with more GPUs
         resp.num_restarts = 0
         resp.ui_url = f"file://{local_app.log_dir}"
         return resp
+
+    def describe_native(self, app_id: str) -> "AppDryRunInfo[PopenRequest] | None":
+        """The retained request lives exactly as long as the app's cache
+        entry -- LRU eviction drops it."""
+        local_app = self._apps.get(app_id)
+        return local_app.dryrun_info if local_app else None
 
     def log_iter(
         self,

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -226,6 +226,56 @@ class SchedulerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             scheduler_mock._validate(app_mock, "local", cfg={})
 
+    def test_describe_native_defaults_to_none(self) -> None:
+        scheduler_mock = SchedulerTest.MockScheduler("test_session")
+        self.assertIsNone(scheduler_mock.describe_native("any_app_id"))
+
+    def test_describe_native_opt_in_round_trips_request(self) -> None:
+        class NativeReadBackScheduler(Scheduler[Mapping[str, CfgVal]]):
+            def __init__(self) -> None:
+                super().__init__("mock", "test_session")
+                self._submitted: dict[str, AppDryRunInfo[str]] = {}
+
+            def schedule(self, dryrun_info: AppDryRunInfo[str]) -> str:
+                app_id = none_throws(dryrun_info.app).name
+                self._submitted[app_id] = dryrun_info
+                return app_id
+
+            def _submit_dryrun(
+                self, app: AppDef, cfg: Mapping[str, CfgVal]
+            ) -> AppDryRunInfo[str]:
+                return AppDryRunInfo(f"native-request-for-{app.name}", str)
+
+            def describe(self, app_id: str) -> DescribeAppResponse | None:
+                return None
+
+            def describe_native(self, app_id: str) -> AppDryRunInfo[str] | None:
+                return self._submitted.get(app_id)
+
+            def list(
+                self, cfg: Mapping[str, CfgVal] | None = None
+            ) -> list[ListAppResponse]:
+                return []
+
+            def _cancel_existing(self, app_id: str) -> None:
+                pass
+
+            def _validate(
+                self, app: AppDef, scheduler: str, cfg: Mapping[str, CfgVal]
+            ) -> None:
+                pass
+
+        scheduler = NativeReadBackScheduler()
+        app = AppDef(
+            name="test_app",
+            roles=[Role(name="sleep", image="", entrypoint="foo.sh")],
+        )
+        app_id = scheduler.submit(app, cfg={})
+
+        info = none_throws(scheduler.describe_native(app_id))
+        self.assertEqual("native-request-for-test_app", info.request)
+        self.assertIsNone(scheduler.describe_native("nonexistent_app_id"))
+
     def test_cancel_not_exists(self) -> None:
         scheduler_mock = SchedulerTest.MockScheduler("test_session")
         with patch.object(scheduler_mock, "_cancel_existing") as cancel_mock:

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -853,6 +853,37 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         assert desc_resp is not None
         self.assertEqual(AppState.SUCCEEDED, desc_resp.state)
 
+    def test_describe_native(self) -> None:
+        role = Role(
+            "role1",
+            image=self.test_dir,
+            entrypoint="touch.sh",
+            args=[join(f"{macros.img_root}", "foo.txt")],
+            num_replicas=2,
+        )
+        app = AppDef(name="test_app", roles=[role])
+        cfg = Opts(log_dir=self.test_dir)
+        self.assertIsNone(self.scheduler.describe_native("test_app_0"))
+
+        app_id = self.scheduler.submit(app, cfg)
+        self.wait(app_id)
+
+        info = self.scheduler.describe_native(app_id)
+        assert info is not None
+        request = info.request
+        self.assertEqual(app_id, request.app_id)
+        self.assertEqual(2, len(request.role_params["role1"]))
+        self.assertEqual(app, info.app)
+
+    def test_describe_native_dropped_on_eviction(self) -> None:
+        evicted = _LocalAppDef("evicted", self.test_dir)
+        evicted.set_state(AppState.SUCCEEDED)
+        self.scheduler._apps["evicted"] = evicted
+
+        self.assertTrue(self.scheduler._evict_lru())
+
+        self.assertIsNone(self.scheduler.describe_native("evicted"))
+
     def test_cancel(self) -> None:
         role = Role(
             "role1",

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -997,9 +997,13 @@ T = TypeVar("T")
 
 
 class AppDryRunInfo(Generic[T]):
-    """Returned by :py:meth:`Scheduler.submit_dryrun <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+    """Wraps a materialized scheduler ``request``.
 
-    Wraps the scheduler ``request`` that *would* have been submitted.
+    Returned by :py:meth:`Scheduler.submit_dryrun
+    <torchx.schedulers.api.Scheduler.submit_dryrun>` (the request that *would*
+    be submitted) and by :py:meth:`Scheduler.describe_native
+    <torchx.schedulers.api.Scheduler.describe_native>` (the request read back
+    from the scheduler for an already-submitted app).
     ``print(info)`` yields a human-readable representation.
     """
 


### PR DESCRIPTION
Summary:
First `describe_native` opt-in: `LocalScheduler.schedule` now keeps the submitted `AppDryRunInfo[PopenRequest]` on the app's `_LocalAppDef` cache entry, and `describe_native(app_id)` returns it.

```
app_id = scheduler.submit(app, cfg)
info = none_throws(scheduler.describe_native(app_id))  # AppDryRunInfo[PopenRequest]
info.request.role_params  # per-replica argv/env/cwd exactly as scheduled
```

This scheduler's data plane is in-process, so retention rides the existing app cache: the read-back lives exactly as long as the app's cache entry and is dropped with it on LRU eviction — no new lifetime to manage. Because the retained object is the submitted info itself, its `app`/`cfg` back-references come back populated.

Stack: seam → **local_scheduler opt-in (this)** → kubernetes opt-in → `Runner.describe_native`.

Differential Revision: D116794790
