### PR TITLE
(feature)[3/4][torchx][schedulers] kubernetes: read the live Volcano job back via describe_native

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -452,6 +452,23 @@ class Scheduler(abc.ABC, Generic[T]):
         """Returns app description, or ``None`` if it no longer exists."""
         raise NotImplementedError()
 
+    def describe_native(self, app_id: str) -> Optional[AppDryRunInfo]:
+        """Returns the scheduler-native request of an already-submitted app.
+
+        The read-side twin of :py:meth:`submit_dryrun`: reads the request back
+        from the scheduler, wrapped in the same
+        :py:class:`~torchx.specs.AppDryRunInfo` (same scheduler-specific
+        ``request`` type). Unlike :py:meth:`describe`, which lossily maps the
+        job description onto :py:class:`~torchx.specs.AppDef`, the returned
+        ``request`` preserves scheduler-specific fields with no ``AppDef``
+        equivalent. The ``app``/``cfg`` back-references are populated only
+        where the scheduler retains them.
+
+        Returns ``None`` if this scheduler does not implement native read-back
+        (the default) or if the app no longer exists.
+        """
+        return None
+
     @abc.abstractmethod
     def list(self, cfg: Mapping[str, CfgVal] | None = None) -> List[ListAppResponse]:
         """Lists jobs on this scheduler."""

--- a/torchx/schedulers/kubernetes_scheduler.py
+++ b/torchx/schedulers/kubernetes_scheduler.py
@@ -1010,6 +1010,29 @@ class KubernetesScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
             state=app_state,
         )
 
+    def describe_native(self, app_id: str) -> AppDryRunInfo[KubernetesJob] | None:
+        """Reads the live Volcano job resource back from the cluster.
+
+        ``images_to_push`` is empty on read-back: workspace images were
+        already pushed at submit time.
+        """
+        from kubernetes.client.rest import ApiException
+
+        namespace, name = app_id.split(":")
+        try:
+            resource = self._custom_objects_api().get_namespaced_custom_object(
+                group="batch.volcano.sh",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="jobs",
+                name=name,
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+        return AppDryRunInfo(KubernetesJob(images_to_push={}, resource=resource), repr)
+
     def log_iter(
         self,
         app_id: str,

--- a/torchx/schedulers/local_scheduler.py
+++ b/torchx/schedulers/local_scheduler.py
@@ -356,7 +356,12 @@ class _LocalAppDef:
     process and has a pid.
     """
 
-    def __init__(self, id: str, log_dir: str) -> None:
+    def __init__(
+        self,
+        id: str,
+        log_dir: str,
+        dryrun_info: "AppDryRunInfo[PopenRequest] | None" = None,
+    ) -> None:
         self.id = id
         # opts.log_dir/<session_name>/<app_id> or /tmp/torchx/<session_name>/<app_id>
         self.log_dir = log_dir
@@ -365,6 +370,7 @@ class _LocalAppDef:
         self.state: AppState = AppState.PENDING
         # time (in seconds since epoch) when the last set_state method() was called
         self.last_updated: float = -1
+        self.dryrun_info = dryrun_info
 
     def add_replica(self, role_name: str, replica: _LocalReplica) -> None:
         procs = self.role_replicas.setdefault(role_name, [])
@@ -807,7 +813,7 @@ class LocalScheduler(Scheduler[Mapping[str, CfgVal]]):
         ), "no app_id collisions expected since uuid4 suffix is used"
 
         os.makedirs(app_log_dir)
-        local_app = _LocalAppDef(app_id, app_log_dir)
+        local_app = _LocalAppDef(app_id, app_log_dir, dryrun_info)
 
         for role_name in request.role_params.keys():
             role_params = request.role_params[role_name]
@@ -1067,6 +1073,12 @@ Reduce requested GPU resources or use a host with more GPUs
         resp.num_restarts = 0
         resp.ui_url = f"file://{local_app.log_dir}"
         return resp
+
+    def describe_native(self, app_id: str) -> "AppDryRunInfo[PopenRequest] | None":
+        """The retained request lives exactly as long as the app's cache
+        entry -- LRU eviction drops it."""
+        local_app = self._apps.get(app_id)
+        return local_app.dryrun_info if local_app else None
 
     def log_iter(
         self,

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -226,6 +226,56 @@ class SchedulerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             scheduler_mock._validate(app_mock, "local", cfg={})
 
+    def test_describe_native_defaults_to_none(self) -> None:
+        scheduler_mock = SchedulerTest.MockScheduler("test_session")
+        self.assertIsNone(scheduler_mock.describe_native("any_app_id"))
+
+    def test_describe_native_opt_in_round_trips_request(self) -> None:
+        class NativeReadBackScheduler(Scheduler[Mapping[str, CfgVal]]):
+            def __init__(self) -> None:
+                super().__init__("mock", "test_session")
+                self._submitted: dict[str, AppDryRunInfo[str]] = {}
+
+            def schedule(self, dryrun_info: AppDryRunInfo[str]) -> str:
+                app_id = none_throws(dryrun_info.app).name
+                self._submitted[app_id] = dryrun_info
+                return app_id
+
+            def _submit_dryrun(
+                self, app: AppDef, cfg: Mapping[str, CfgVal]
+            ) -> AppDryRunInfo[str]:
+                return AppDryRunInfo(f"native-request-for-{app.name}", str)
+
+            def describe(self, app_id: str) -> DescribeAppResponse | None:
+                return None
+
+            def describe_native(self, app_id: str) -> AppDryRunInfo[str] | None:
+                return self._submitted.get(app_id)
+
+            def list(
+                self, cfg: Mapping[str, CfgVal] | None = None
+            ) -> list[ListAppResponse]:
+                return []
+
+            def _cancel_existing(self, app_id: str) -> None:
+                pass
+
+            def _validate(
+                self, app: AppDef, scheduler: str, cfg: Mapping[str, CfgVal]
+            ) -> None:
+                pass
+
+        scheduler = NativeReadBackScheduler()
+        app = AppDef(
+            name="test_app",
+            roles=[Role(name="sleep", image="", entrypoint="foo.sh")],
+        )
+        app_id = scheduler.submit(app, cfg={})
+
+        info = none_throws(scheduler.describe_native(app_id))
+        self.assertEqual("native-request-for-test_app", info.request)
+        self.assertIsNone(scheduler.describe_native("nonexistent_app_id"))
+
     def test_cancel_not_exists(self) -> None:
         scheduler_mock = SchedulerTest.MockScheduler("test_session")
         with patch.object(scheduler_mock, "_cancel_existing") as cancel_mock:

--- a/torchx/schedulers/test/kubernetes_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_scheduler_test.py
@@ -944,6 +944,61 @@ spec:
         with self.assertRaises(ApiException):
             scheduler.describe(app_id)
 
+    @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object")
+    def test_describe_native(self, get_namespaced_custom_object: MagicMock) -> None:
+        resource = {
+            "apiVersion": "batch.volcano.sh/v1alpha1",
+            "kind": "Job",
+            "metadata": {"name": "testid"},
+            "spec": {"queue": "testqueue"},
+        }
+        get_namespaced_custom_object.return_value = resource
+        scheduler = create_scheduler("test")
+
+        info = scheduler.describe_native("testnamespace:testid")
+
+        args, kwargs = get_namespaced_custom_object.call_args
+        self.assertEqual(
+            kwargs,
+            {
+                "group": "batch.volcano.sh",
+                "version": "v1alpha1",
+                "namespace": "testnamespace",
+                "plural": "jobs",
+                "name": "testid",
+            },
+        )
+        assert info is not None
+        self.assertEqual(
+            kubernetes_scheduler.KubernetesJob(images_to_push={}, resource=resource),
+            info.request,
+        )
+
+    @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object")
+    def test_describe_native_not_found(
+        self, get_namespaced_custom_object: MagicMock
+    ) -> None:
+        from kubernetes.client.rest import ApiException
+
+        get_namespaced_custom_object.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        scheduler = create_scheduler("test")
+        self.assertIsNone(scheduler.describe_native("testnamespace:testid"))
+
+    @patch("kubernetes.client.CustomObjectsApi.get_namespaced_custom_object")
+    def test_describe_native_api_exception_other(
+        self, get_namespaced_custom_object: MagicMock
+    ) -> None:
+        from kubernetes.client.rest import ApiException
+
+        get_namespaced_custom_object.side_effect = ApiException(
+            status=500, reason="Internal Server Error"
+        )
+        scheduler = create_scheduler("test")
+        with self.assertRaises(ApiException):
+            scheduler.describe_native("testnamespace:testid")
+
     def test_runopts(self) -> None:
         scheduler = kubernetes_scheduler.create_scheduler("foo")
         runopts = scheduler.run_opts()

--- a/torchx/schedulers/test/local_scheduler_test.py
+++ b/torchx/schedulers/test/local_scheduler_test.py
@@ -853,6 +853,37 @@ class LocalDirectorySchedulerTest(unittest.TestCase, LocalSchedulerTestUtil):
         assert desc_resp is not None
         self.assertEqual(AppState.SUCCEEDED, desc_resp.state)
 
+    def test_describe_native(self) -> None:
+        role = Role(
+            "role1",
+            image=self.test_dir,
+            entrypoint="touch.sh",
+            args=[join(f"{macros.img_root}", "foo.txt")],
+            num_replicas=2,
+        )
+        app = AppDef(name="test_app", roles=[role])
+        cfg = Opts(log_dir=self.test_dir)
+        self.assertIsNone(self.scheduler.describe_native("test_app_0"))
+
+        app_id = self.scheduler.submit(app, cfg)
+        self.wait(app_id)
+
+        info = self.scheduler.describe_native(app_id)
+        assert info is not None
+        request = info.request
+        self.assertEqual(app_id, request.app_id)
+        self.assertEqual(2, len(request.role_params["role1"]))
+        self.assertEqual(app, info.app)
+
+    def test_describe_native_dropped_on_eviction(self) -> None:
+        evicted = _LocalAppDef("evicted", self.test_dir)
+        evicted.set_state(AppState.SUCCEEDED)
+        self.scheduler._apps["evicted"] = evicted
+
+        self.assertTrue(self.scheduler._evict_lru())
+
+        self.assertIsNone(self.scheduler.describe_native("evicted"))
+
     def test_cancel(self) -> None:
         role = Role(
             "role1",

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -997,9 +997,13 @@ T = TypeVar("T")
 
 
 class AppDryRunInfo(Generic[T]):
-    """Returned by :py:meth:`Scheduler.submit_dryrun <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+    """Wraps a materialized scheduler ``request``.
 
-    Wraps the scheduler ``request`` that *would* have been submitted.
+    Returned by :py:meth:`Scheduler.submit_dryrun
+    <torchx.schedulers.api.Scheduler.submit_dryrun>` (the request that *would*
+    be submitted) and by :py:meth:`Scheduler.describe_native
+    <torchx.schedulers.api.Scheduler.describe_native>` (the request read back
+    from the scheduler for an already-submitted app).
     ``print(info)`` yields a human-readable representation.
     """
 


### PR DESCRIPTION
Summary:
`KubernetesScheduler.describe_native` fetches the full Volcano job custom object (`get_namespaced_custom_object` — spec and cluster-populated status, not the status-only view `describe` uses) and returns it as `AppDryRunInfo[KubernetesJob]`, the same request type `submit_dryrun` produces:

```
info = scheduler.describe_native("namespace:jobname")  # AppDryRunInfo[KubernetesJob] | None
info.request.resource  # the live job resource, as stored by the cluster
```

`describe()` collapses this resource into `AppDef` roles and drops everything Volcano-specific (queue, scheduler policies, per-task pod templates); the read-back preserves it all. 404 maps to `None` per the seam contract; other API errors propagate.

NOTE: `images_to_push` is empty on read-back — workspace images were already pushed at submit time, so there is nothing left to push.

Stack: seam → local_scheduler opt-in → **kubernetes opt-in (this)** → `Runner.describe_native`.

Differential Revision: D116794791
