### PR TITLE
(feature)[1/4][torchx][schedulers] Add Scheduler.describe_native — read-side twin of submit_dryrun

### DIFF
--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -452,6 +452,23 @@ class Scheduler(abc.ABC, Generic[T]):
         """Returns app description, or ``None`` if it no longer exists."""
         raise NotImplementedError()
 
+    def describe_native(self, app_id: str) -> Optional[AppDryRunInfo]:
+        """Returns the scheduler-native request of an already-submitted app.
+
+        The read-side twin of :py:meth:`submit_dryrun`: reads the request back
+        from the scheduler, wrapped in the same
+        :py:class:`~torchx.specs.AppDryRunInfo` (same scheduler-specific
+        ``request`` type). Unlike :py:meth:`describe`, which lossily maps the
+        job description onto :py:class:`~torchx.specs.AppDef`, the returned
+        ``request`` preserves scheduler-specific fields with no ``AppDef``
+        equivalent. The ``app``/``cfg`` back-references are populated only
+        where the scheduler retains them.
+
+        Returns ``None`` if this scheduler does not implement native read-back
+        (the default) or if the app no longer exists.
+        """
+        return None
+
     @abc.abstractmethod
     def list(self, cfg: Mapping[str, CfgVal] | None = None) -> List[ListAppResponse]:
         """Lists jobs on this scheduler."""

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -226,6 +226,56 @@ class SchedulerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             scheduler_mock._validate(app_mock, "local", cfg={})
 
+    def test_describe_native_defaults_to_none(self) -> None:
+        scheduler_mock = SchedulerTest.MockScheduler("test_session")
+        self.assertIsNone(scheduler_mock.describe_native("any_app_id"))
+
+    def test_describe_native_opt_in_round_trips_request(self) -> None:
+        class NativeReadBackScheduler(Scheduler[Mapping[str, CfgVal]]):
+            def __init__(self) -> None:
+                super().__init__("mock", "test_session")
+                self._submitted: dict[str, AppDryRunInfo[str]] = {}
+
+            def schedule(self, dryrun_info: AppDryRunInfo[str]) -> str:
+                app_id = none_throws(dryrun_info.app).name
+                self._submitted[app_id] = dryrun_info
+                return app_id
+
+            def _submit_dryrun(
+                self, app: AppDef, cfg: Mapping[str, CfgVal]
+            ) -> AppDryRunInfo[str]:
+                return AppDryRunInfo(f"native-request-for-{app.name}", str)
+
+            def describe(self, app_id: str) -> DescribeAppResponse | None:
+                return None
+
+            def describe_native(self, app_id: str) -> AppDryRunInfo[str] | None:
+                return self._submitted.get(app_id)
+
+            def list(
+                self, cfg: Mapping[str, CfgVal] | None = None
+            ) -> list[ListAppResponse]:
+                return []
+
+            def _cancel_existing(self, app_id: str) -> None:
+                pass
+
+            def _validate(
+                self, app: AppDef, scheduler: str, cfg: Mapping[str, CfgVal]
+            ) -> None:
+                pass
+
+        scheduler = NativeReadBackScheduler()
+        app = AppDef(
+            name="test_app",
+            roles=[Role(name="sleep", image="", entrypoint="foo.sh")],
+        )
+        app_id = scheduler.submit(app, cfg={})
+
+        info = none_throws(scheduler.describe_native(app_id))
+        self.assertEqual("native-request-for-test_app", info.request)
+        self.assertIsNone(scheduler.describe_native("nonexistent_app_id"))
+
     def test_cancel_not_exists(self) -> None:
         scheduler_mock = SchedulerTest.MockScheduler("test_session")
         with patch.object(scheduler_mock, "_cancel_existing") as cancel_mock:

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -997,9 +997,13 @@ T = TypeVar("T")
 
 
 class AppDryRunInfo(Generic[T]):
-    """Returned by :py:meth:`Scheduler.submit_dryrun <torchx.schedulers.api.Scheduler.submit_dryrun>`.
+    """Wraps a materialized scheduler ``request``.
 
-    Wraps the scheduler ``request`` that *would* have been submitted.
+    Returned by :py:meth:`Scheduler.submit_dryrun
+    <torchx.schedulers.api.Scheduler.submit_dryrun>` (the request that *would*
+    be submitted) and by :py:meth:`Scheduler.describe_native
+    <torchx.schedulers.api.Scheduler.describe_native>` (the request read back
+    from the scheduler for an already-submitted app).
     ``print(info)`` yields a human-readable representation.
     """
 


### PR DESCRIPTION
Summary:
`Scheduler.describe(app_id)` is lossy by construction: it maps the scheduler's job description onto `AppDef`, dropping every scheduler-specific field (per-task-group env, application metadata, topology constraints, restart policies). Tools that need those fields for live jobs — ~15 files in `genai/msl/rl` alone, plus farm's status path — bypass torchx for raw scheduler RPCs or `mslsc` subprocesses.

This diff adds the read-side twin of `AppDryRunInfo.request`: an optional `Scheduler.describe_native(app_id)` that reads the materialized request back from the scheduler, wrapped in the same `AppDryRunInfo` — the same scheduler-specific request type `T` as `submit_dryrun`:

```
info = scheduler.describe_native(app_id)  # AppDryRunInfo[KubernetesJob] | None
info.request                              # the request as materialized on the scheduler
```

The base returns `None` (also the not-found result); schedulers opt in by overriding with a narrowed return type — the typing idiom `_submit_dryrun` already uses (bare `AppDryRunInfo` on the base, parameterized on the concrete class).

**Why reuse `AppDryRunInfo` rather than return the raw request:** write side and read side then share one type, so dryrun-vs-live parity checks compare `.request` directly and consumers keep one vocabulary. The rejected alternative — making `Scheduler` doubly generic (`Scheduler[Cfg, Req]`) for a precisely-typed base signature — breaks every existing `Scheduler[Opts]` subscription.

Stack: **seam (this)** → local_scheduler opt-in → kubernetes opt-in → `Runner.describe_native`.

Differential Revision: D116794793
