### PR TITLE
(bugfix)[torchx][docker] describe() returns str Role.image, not docker-py Image (#1409)

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -42,6 +42,7 @@ from torchx.specs.api import (
     Role,
     RoleStatus,
     runopts,
+    UNKNOWN,
     VolumeMount,
 )
 from torchx.workspace.docker_workspace import DockerWorkspaceMixin
@@ -414,10 +415,16 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
             replica_id = container.labels[LABEL_REPLICA_ID]
 
             if role not in roles:
+                # docker-py returns None once the image record is deleted
+                image = container.image
+                if image is None:
+                    image_name = UNKNOWN
+                else:
+                    image_name = image.tags[0] if image.tags else image.id
                 roles[role] = Role(
                     name=role,
                     num_replicas=0,
-                    image=container.image,
+                    image=image_name,
                 )
                 roles_statuses[role] = RoleStatus(role, [])
             roles[role].num_replicas += 1

--- a/torchx/schedulers/test/docker_scheduler_test.py
+++ b/torchx/schedulers/test/docker_scheduler_test.py
@@ -585,6 +585,42 @@ class DockerSchedulerTest(unittest.TestCase):
             msg="per-replica ids and states must be reported in container order",
         )
 
+    def test_describe_publishes_image_as_str(self) -> None:
+        tagged = _mock_container()
+        tagged.image.tags = ["pytorch/torchx:latest"]
+        untagged = _mock_container()
+        untagged.image.tags = []
+        untagged.image.id = "sha256:0123"
+        gone = _mock_container()
+        gone.image = None
+
+        for container, want, why in (
+            (
+                tagged,
+                "pytorch/torchx:latest",
+                "a tagged image must publish its first repo tag",
+            ),
+            (
+                untagged,
+                "sha256:0123",
+                "an untagged image must fall back to the image id",
+            ),
+            (
+                gone,
+                specs.UNKNOWN,
+                "a deleted image record must publish the UNKNOWN sentinel",
+            ),
+        ):
+            with self.subTest(why=why):
+                client = MagicMock()
+                client.containers.list.return_value = [container]
+                with patch.object(DockerScheduler, "_docker_client", client):
+                    desc = self.scheduler.describe("app_id_1")
+                assert (
+                    desc is not None
+                ), "an app with containers must have a description"
+                self.assertEqual(want, desc.roles[0].image, msg=why)
+
     def test_describe_all_replicas_succeeded(self) -> None:
         containers = [
             _mock_container(status="exited", exit_code=0, replica_id=i)


### PR DESCRIPTION
Summary:

`DockerScheduler.describe()` filled `Role.image` with docker-py's `Container.image` — an `Image` object (or `None` once the image record is deleted) where `Role.image` declares `str` — so `torchx describe` pprinted the object repr and the tracker event's `app_image` recorded it instead of the image name.

- **Before**: `describe(app_id).roles[0].image` → `<Image: 'busybox:latest'>` (docker-py model object; `None` if the image was deleted)
- **After**: → `'busybox:latest'` — first repo tag; image id (`sha256:...`) when the image is untagged; `specs.UNKNOWN` when docker no longer has the image record (docker-py's documented `Container.image -> None` path)

Reviewed By: athmasagar

Differential Revision: D116754782
