### PR TITLE
(cleanup)[torchx][docker] Remove dead UNKNOWN state init in describe() (#1410)

### DIFF
--- a/torchx/schedulers/docker_scheduler.py
+++ b/torchx/schedulers/docker_scheduler.py
@@ -441,7 +441,6 @@ class DockerScheduler(DockerWorkspaceMixin, Scheduler[Opts]):
             )
             states.append(state)
 
-        state = AppState.UNKNOWN
         if all(is_terminal(state) for state in states):
             if all(state == AppState.SUCCEEDED for state in states):
                 state = AppState.SUCCEEDED


### PR DESCRIPTION
Summary:

`state = AppState.UNKNOWN` in `DockerScheduler.describe()` is unconditionally overwritten — both arms of the if/else that follows assign `state` (and the else arm's `next()` cannot raise: it only runs when a non-terminal state exists).

Reviewed By: athmasagar

Differential Revision: D116754645
