### PR TITLE
Load file components as real modules, not exec'd source (#1414)

### DIFF
--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -7,12 +7,16 @@
 # pyre-strict
 
 import abc
-import copy
+import hashlib
 import importlib
+import importlib.util
 import inspect
 import logging
 import os
 import pkgutil
+import re
+import sys
+import threading
 from dataclasses import dataclass
 from inspect import getmembers, isfunction
 from pathlib import Path
@@ -263,6 +267,176 @@ class ModuleComponentsFinder(ComponentsFinder):
         return component_defs
 
 
+def _package_identity(filepath: str) -> tuple[str, str] | None:
+    """
+    Derives the dotted module name of the python file at ``filepath`` from its
+    enclosing package (the chain of parent directories carrying ``__init__.py``).
+
+    Returns:
+        ``(module_name, sys_path_root)`` where ``sys_path_root`` is the directory
+        that must be on ``sys.path`` for ``module_name`` (and absolute imports of
+        the file's package siblings) to be importable.
+        ``None`` if ``filepath`` is not part of a package. A dir or stem whose
+        name is not a valid identifier cannot appear in a dotted import, so it
+        bounds the walk.
+    """
+    stem = Path(filepath).stem
+    if not stem.isidentifier():
+        return None
+    directory = os.path.dirname(filepath)
+    parts = [stem]
+    while os.path.isfile(os.path.join(directory, "__init__.py")):
+        basename = os.path.basename(directory)
+        if not basename.isidentifier():
+            break
+        parent = os.path.dirname(directory)
+        parts.append(basename)
+        if parent == directory:
+            break
+        directory = parent
+    if len(parts) == 1:
+        return None
+    return ".".join(reversed(parts)), directory
+
+
+def _is_same_file(path1: str, path2: str) -> bool:
+    try:
+        return os.path.samefile(path1, path2)
+    except OSError:
+        return False
+
+
+# RLock: a loading component file can itself trigger a same-thread load
+_LOAD_LOCK = threading.RLock()
+
+
+def _exec_src_as_module(filepath: str) -> ModuleType:
+    """
+    Loads a component file that does not exist on the local filesystem but whose
+    source is resolvable through ``read_conf_file`` (e.g. served by a
+    ``torchx.file`` entrypoint) by exec-ing the source into a synthetic module.
+    """
+    abspath = os.path.abspath(filepath)
+    # the path digest disambiguates distinct paths that collapse to the same
+    # name under the non-word substitution (`/a/b-c.py` vs `/a/b_c.py`)
+    modname = (
+        "torchx_component_file_"
+        + re.sub(r"\W", "_", abspath).strip("_")
+        + "_"
+        + hashlib.blake2b(abspath.encode(), digest_size=4).hexdigest()
+    )
+    with _LOAD_LOCK:
+        existing = sys.modules.get(modname)
+        if existing is not None:
+            return existing
+
+        file_source = read_conf_file(filepath)
+        module = ModuleType(modname)
+        module.__file__ = abspath
+        sys.modules[modname] = module
+        try:
+            exec(compile(file_source, abspath, "exec"), module.__dict__)  # noqa: P204
+        except BaseException:
+            sys.modules.pop(modname, None)
+            raise
+        return module
+
+
+def _load_file_as_module(filepath: str) -> ModuleType:
+    """
+    Loads the python file at ``filepath`` as a regular module, mirroring how the
+    interpreter itself would load it:
+
+    #. a file inside a package (parent dirs carry ``__init__.py``) loads under
+       its dotted module name with the package root's parent dir appended to
+       ``sys.path`` (as with ``python -m pkg.mod``), so absolute imports of the
+       file's package siblings resolve;
+    #. a standalone file loads under its stem with its directory appended to
+       ``sys.path`` (as with ``python file.py``), so imports of neighboring
+       modules resolve;
+    #. a path not present on the local filesystem falls back to
+       :py:func:`_exec_src_as_module`.
+
+    The module is registered in ``sys.modules``, so functions and classes it
+    defines carry their real ``__module__`` (instead of the finder's) and
+    machinery that resolves ``sys.modules[obj.__module__]`` (``typing``,
+    ``dataclasses``, ``pickle``) works on them. For a package file the parent
+    package is imported first (as a real import would), so relative imports
+    inside the component file resolve; if the package name is shadowed by a
+    different root earlier on ``sys.path``, a warning names both roots.
+    Loading the same file again returns the already-loaded module.
+
+    Limitation: when the derived module name is taken by a DIFFERENT file
+    (e.g. the same dotted name reachable from another ``sys.path`` root), the
+    module loads under a ``_<n>``-suffixed name. That name resolves through
+    ``sys.modules`` but is not importable by the import system, so
+    re-resolution that round-trips through an import (e.g. unpickling in a
+    fresh process) does not work for such modules.
+    """
+    abspath = os.path.abspath(filepath)
+    if not os.path.isfile(abspath):
+        return _exec_src_as_module(filepath)
+
+    identity = _package_identity(abspath)
+    if identity:
+        modname, sys_path_root = identity
+    else:
+        modname, sys_path_root = Path(abspath).stem, os.path.dirname(abspath)
+
+    base_modname = modname
+    with _LOAD_LOCK:
+        collision = 0
+        while (existing := sys.modules.get(modname)) is not None:
+            existing_file = getattr(existing, "__file__", None)
+            if existing_file and _is_same_file(existing_file, abspath):
+                return existing
+            collision += 1
+            modname = f"{base_modname}_{collision}"
+
+        spec = importlib.util.spec_from_file_location(modname, abspath)
+        if spec is None or spec.loader is None:
+            raise ComponentNotFoundException(
+                f"cannot create a module spec for `{abspath}`;"
+                " make sure the file is a regular python source file"
+            )
+        loader = spec.loader
+        module = importlib.util.module_from_spec(spec)
+
+        appended_sys_path = sys_path_root not in sys.path
+        if appended_sys_path:
+            sys.path.append(sys_path_root)
+        parent_name, _, leaf_name = modname.rpartition(".")
+        parent: ModuleType | None = None
+        sys.modules[modname] = module
+        try:
+            if parent_name:
+                parent = importlib.import_module(parent_name)
+                parent_dir = os.path.dirname(getattr(parent, "__file__", "") or "")
+                if parent_dir and not _is_same_file(
+                    parent_dir, os.path.dirname(abspath)
+                ):
+                    logger.warning(
+                        "package `%s` resolves to `%s` (earlier on sys.path),"
+                        " which shadows this component file's own package root"
+                        " `%s`; sibling imports inside `%s` will resolve"
+                        " against the shadowing package",
+                        parent_name,
+                        parent_dir,
+                        os.path.dirname(abspath),
+                        abspath,
+                    )
+                    parent = None
+            loader.exec_module(module)
+        except BaseException:
+            sys.modules.pop(modname, None)
+            if appended_sys_path and sys_path_root in sys.path:
+                sys.path.remove(sys_path_root)
+            raise
+        if parent is not None:
+            setattr(parent, leaf_name, module)
+        return module
+
+
 class CustomComponentsFinder(ComponentsFinder):
     def __init__(self, filepath: str, function_name: str) -> None:
         self._filepath = filepath
@@ -284,16 +458,12 @@ class CustomComponentsFinder(ComponentsFinder):
             self._filepath, self._function_name, validators
         )
 
-        file_source = read_conf_file(self._filepath)
-        namespace = copy.copy(globals())
-        # so that __file__ used inside the component points to the correct file
-        namespace["__file__"] = os.path.abspath(self._filepath)
-        exec(file_source, namespace)  # noqa: P204
-        if self._function_name not in namespace:
+        module = _load_file_as_module(self._filepath)
+        if self._function_name not in vars(module):
             raise ComponentNotFoundException(
                 f"Function {self._function_name} does not exist in file {self._filepath}"
             )
-        app_fn = namespace[self._function_name]
+        app_fn = getattr(module, self._function_name)
         fn_desc, _ = get_fn_docstring(app_fn)
         return [
             _Component(

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -9,6 +9,7 @@
 
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from importlib.metadata import EntryPoints
@@ -242,6 +243,198 @@ to your component (see: https://meta-pytorch.org/torchx/latest/component_best_pr
     def test_get_component_invalid(self) -> None:
         with self.assertRaises(ComponentValidationException):
             get_component(f"{current_file_path()}:invalid_component")
+
+
+class ModuleIdentityLoadingTest(unittest.TestCase):
+    """Component files load as regular modules (not exec'd into the finder's globals)."""
+
+    _PKG_COMPONENT = """
+from torchx.specs import AppDef, Role
+
+from idpkg.helper import ROLE_NAME
+
+
+def comp(msg: str = "hello") -> AppDef:
+    \"\"\"Test component
+
+    Args:
+        msg: message
+    \"\"\"
+    return AppDef(msg, roles=[Role(name=ROLE_NAME, image="img", entrypoint="echo")])
+"""
+
+    _STANDALONE_COMPONENT = """
+from torchx.specs import AppDef, Role
+
+from id_neighbor import ROLE_NAME
+
+
+def comp(msg: str = "hello") -> AppDef:
+    \"\"\"Test component
+
+    Args:
+        msg: message
+    \"\"\"
+    return AppDef(msg, roles=[Role(name=ROLE_NAME, image="img", entrypoint="echo")])
+"""
+
+    _HELPER = 'ROLE_NAME = "sibling"\n'
+
+    def setUp(self) -> None:
+        finder._components = None
+        registry.cache_clear()
+
+        self.test_dir = Path(tempfile.mkdtemp("torchx_finder_module_identity_test"))
+
+        pkg_dir = self.test_dir / "idpkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "helper.py").write_text(self._HELPER)
+        (pkg_dir / "idcomp.py").write_text(self._PKG_COMPONENT)
+
+        standalone_dir = self.test_dir / "standalone"
+        standalone_dir.mkdir()
+        (standalone_dir / "id_neighbor.py").write_text(self._HELPER)
+        (standalone_dir / "id_standalone_comp.py").write_text(
+            self._STANDALONE_COMPONENT
+        )
+
+        self._orig_sys_path = list(sys.path)
+
+    def tearDown(self) -> None:
+        finder._components = None
+        registry.cache_clear()
+        sys.path[:] = self._orig_sys_path
+        for mod in [
+            m
+            for m, loaded in sys.modules.items()
+            if m.startswith(("idpkg", "id_neighbor", "id_standalone_comp"))
+            or str(self.test_dir) in (getattr(loaded, "__file__", None) or "")
+        ]:
+            del sys.modules[mod]
+        shutil.rmtree(self.test_dir)
+
+    def test_package_file_component_imports_siblings(self) -> None:
+        component = get_component(f"{self.test_dir / 'idpkg' / 'idcomp.py'}:comp")
+        app = component.fn()
+        self.assertEqual("sibling", app.roles[0].name)
+
+    def test_package_file_component_has_module_identity(self) -> None:
+        filepath = str(self.test_dir / "idpkg" / "idcomp.py")
+        component = get_component(f"{filepath}:comp")
+        self.assertEqual("idpkg.idcomp", component.fn.__module__)
+        self.assertIn("idpkg.idcomp", sys.modules)
+        self.assertEqual(filepath, sys.modules["idpkg.idcomp"].__file__)
+
+    def test_package_file_component_supports_relative_imports(self) -> None:
+        (self.test_dir / "idpkg" / "relcomp.py").write_text(
+            self._PKG_COMPONENT.replace(
+                "from idpkg.helper import ROLE_NAME",
+                "from .helper import ROLE_NAME",
+            )
+        )
+        component = get_component(f"{self.test_dir / 'idpkg' / 'relcomp.py'}:comp")
+        self.assertEqual(
+            "sibling",
+            component.fn().roles[0].name,
+            "the parent package is imported before the leaf, so relative"
+            " imports inside a package component file must resolve",
+        )
+        self.assertIs(
+            sys.modules["idpkg.relcomp"],
+            sys.modules["idpkg"].relcomp,
+            "the loaded leaf must be set as an attribute on its parent"
+            " package, as a real import would",
+        )
+
+    def test_shadowed_package_root_warns(self) -> None:
+        shadow_root = self.test_dir / "shadow_root"
+        shadow_pkg = shadow_root / "idpkg"
+        shadow_pkg.mkdir(parents=True)
+        (shadow_pkg / "__init__.py").write_text("")
+        (shadow_pkg / "helper.py").write_text('ROLE_NAME = "shadowed"\n')
+        (shadow_pkg / "shadowcomp.py").write_text(self._PKG_COMPONENT)
+        sys.path.insert(0, str(self.test_dir))
+        with self.assertLogs("torchx.specs.finder", level="WARNING") as logs:
+            get_component(f"{shadow_pkg / 'shadowcomp.py'}:comp")
+        self.assertTrue(
+            any("shadows" in line for line in logs.output),
+            "loading a component whose package name resolves to a different"
+            " sys.path root must warn about the shadowing",
+        )
+
+    def test_non_identifier_package_dir_loads_standalone(self) -> None:
+        pkg_dir = self.test_dir / "my-pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "helper.py").write_text(self._HELPER)
+        (pkg_dir / "dashcomp.py").write_text(
+            self._STANDALONE_COMPONENT.replace("id_neighbor", "helper")
+        )
+        component = get_component(f"{pkg_dir / 'dashcomp.py'}:comp")
+        self.assertEqual(
+            "dashcomp",
+            component.fn.__module__,
+            "a package dir that is not a valid identifier cannot appear in a"
+            " dotted name; the file must load standalone under its stem",
+        )
+        self.assertEqual("sibling", component.fn().roles[0].name)
+
+    def test_standalone_file_component_imports_neighbors(self) -> None:
+        filepath = str(self.test_dir / "standalone" / "id_standalone_comp.py")
+        component = get_component(f"{filepath}:comp")
+        self.assertEqual("id_standalone_comp", component.fn.__module__)
+        app = component.fn()
+        self.assertEqual("sibling", app.roles[0].name)
+
+    def test_reload_returns_same_module(self) -> None:
+        filepath = str(self.test_dir / "idpkg" / "idcomp.py")
+        fn1 = get_component(f"{filepath}:comp").fn
+        fn2 = get_component(f"{filepath}:comp").fn
+        self.assertIs(fn1, fn2)
+
+    def test_module_name_collision_gets_unique_name(self) -> None:
+        (self.test_dir / "standalone" / "logging.py").write_text(
+            self._STANDALONE_COMPONENT
+        )
+        import logging as stdlib_logging
+
+        filepath = str(self.test_dir / "standalone" / "logging.py")
+        component = get_component(f"{filepath}:comp")
+        self.assertEqual("logging_1", component.fn.__module__)
+        self.assertIs(stdlib_logging, sys.modules["logging"])
+
+    def test_virtual_file_execs_into_synthetic_module(self) -> None:
+        filepath = str(self.test_dir / "does_not_exist.py")
+        with (
+            patch(
+                "torchx.specs.finder.read_conf_file",
+                return_value=self._HELPER + VIRTUAL_COMPONENT_SRC,
+            ),
+            patch(
+                "torchx.specs.file_linter.read_conf_file",
+                return_value=self._HELPER + VIRTUAL_COMPONENT_SRC,
+            ),
+        ):
+            component = get_component(f"{filepath}:comp")
+        self.assertTrue(component.fn.__module__.startswith("torchx_component_file_"))
+        self.assertEqual(filepath, sys.modules[component.fn.__module__].__file__)
+        app = component.fn()
+        self.assertEqual("sibling", app.roles[0].name)
+
+
+VIRTUAL_COMPONENT_SRC = """
+from torchx.specs import AppDef, Role
+
+
+def comp(msg: str = "hello") -> AppDef:
+    \"\"\"Test component
+
+    Args:
+        msg: message
+    \"\"\"
+    return AppDef(msg, roles=[Role(name=ROLE_NAME, image="img", entrypoint="echo")])
+"""
 
 
 class GetBuiltinSourceTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

Component files named as `file.py:fn` were `exec()`d into a copy of the finder's globals, so the functions and classes they define had no module identity — `fn.__module__` read `torchx.specs.finder`, nothing registered in `sys.modules`, and the file could not import its own package siblings:

**Before**

```
$ torchx run ./mypkg/comp.py:comp    # comp.py: from mypkg.helper import ROLE_NAME
ModuleNotFoundError: No module named 'mypkg'
```

**After**

```
$ torchx run ./mypkg/comp.py:comp
local_cwd://torchx/comp-abc123
>>> get_component("./mypkg/comp.py:comp").fn.__module__
'mypkg.comp'
```

`CustomComponentsFinder` now loads the file the way the interpreter would: a file inside a package (its parent dirs carry `__init__.py`) loads under its dotted module name with the package root's parent dir appended to `sys.path` (as with `python -m pkg.mod`); a standalone file loads under its stem with its dir appended (as with `python file.py`). Loaded modules register in `sys.modules`, so machinery resolving `sys.modules[obj.__module__]` (`typing`, `dataclasses`, `pickle`) works on component objects, and re-resolving the same file reuses the module instead of re-exec'ing it.

Paths served by a `torchx.file` entrypoint rather than the local filesystem still exec, but into a synthetic module registered under a path-derived name.

This deletes the need for the `sys.path.append(...)` bootstrap every genai/msl component file carries (e.g. `msl_tools/launching/torchx/mast.py`, `rl/mast/train_rl.py`) and for `rl/mast/*`'s `Cls.__module__ = fn.__module__` repair of the exec-time identity loss (P1944426339).

NOTE: a component file that referenced a name it never imported (accidentally leaked from the finder's globals, e.g. `AppDef`) now raises `NameError`; that behavior was an implementation accident.

Differential Revision: D116797515
