### PR TITLE
Accept class-based components with a build() contract (#1416)

### DIFF
--- a/torchx/specs/file_linter.py
+++ b/torchx/specs/file_linter.py
@@ -353,6 +353,21 @@ class ComponentFnVisitor(ast.NodeVisitor):
         for validator in self.validators:
             self.linter_errors += validator.validate(node)
 
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """
+        Accepts a class as the component (``cls(**args).build()`` is the
+        component function — see ``torchx.specs.finder``). Statically only the
+        return annotation of a ``build`` defined in the class body is checked;
+        ``build`` may be inherited, in which case the finder validates its
+        presence at load time.
+        """
+        if node.name != self.component_function_name:
+            return
+        self.visited_function = True
+        for stmt in node.body:
+            if isinstance(stmt, ast.FunctionDef) and stmt.name == "build":
+                self.linter_errors += ReturnTypeValidator("AppDef").validate(stmt)
+
 
 def validate(
     path: str,

--- a/torchx/specs/finder.py
+++ b/torchx/specs/finder.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import abc
+import functools
 import hashlib
 import importlib
 import importlib.util
@@ -21,7 +22,7 @@ from dataclasses import dataclass, replace
 from inspect import getmembers, isfunction
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Generator
+from typing import Callable, cast, Generator, Protocol
 
 from torchx.specs import AppDef
 from torchx.specs.file_linter import (
@@ -459,13 +460,37 @@ def _load_file_as_module(filepath: str) -> ModuleType:
         return module
 
 
+class _Buildable(Protocol):
+    def build(self) -> AppDef: ...
+
+
+def _component_fn_from_class(cls: Callable[..., _Buildable]) -> Callable[..., AppDef]:
+    """
+    Adapts a class-based component (a class whose constructor params are the
+    component's args and whose ``build(self) -> AppDef`` produces the app) into
+    a component function. ``functools.wraps`` carries the class's signature,
+    docstring, and identity so arg parsing and help rendering see the class.
+    """
+
+    @functools.wraps(cls, updated=())
+    def component_fn(*args: object, **kwargs: object) -> AppDef:
+        return cls(*args, **kwargs).build()
+
+    return component_fn
+
+
 class CustomComponentsFinder(ComponentsFinder):
     """
-    Finds a single component addressed as ``PATH:FUNCTION_NAME``, where ``PATH``
+    Finds a single component addressed as ``PATH:NAME``, where ``PATH``
     is either a path to a python file (``path/to/comp.py:fn``) or a dotted
     module path (``pkg.module:fn``). A ``PATH`` that exists as a file wins over
     the module interpretation; the component must be defined in the named
     file/module (not merely imported into it).
+
+    ``NAME`` is a component function or a class implementing the class-based
+    component contract: constructor params are the component's args and
+    ``build(self) -> AppDef`` produces the app (see
+    :py:func:`_component_fn_from_class`).
     """
 
     def __init__(self, filepath: str, function_name: str) -> None:
@@ -518,6 +543,18 @@ class CustomComponentsFinder(ComponentsFinder):
                 f"Function {self._function_name} does not exist in {self._filepath}"
             )
         app_fn = getattr(module, self._function_name)
+        if inspect.isclass(app_fn):
+            if callable(getattr(app_fn, "build", None)):
+                # the callable-`build` check above is the runtime guard for
+                # this narrowing
+                app_fn = _component_fn_from_class(
+                    cast(Callable[..., _Buildable], app_fn)
+                )
+            else:
+                validation_errors.append(
+                    f"Class component `{self._function_name}` must define"
+                    " a `build(self) -> AppDef` method"
+                )
         fn_desc, _ = get_fn_docstring(app_fn)
         return [
             _Component(

--- a/torchx/specs/test/file_linter_test.py
+++ b/torchx/specs/test/file_linter_test.py
@@ -161,6 +161,30 @@ def _test_single_element_tuple_type(arg0: tuple[str]) -> AppDef:
     return IGNORED
 
 
+class _TestClassComponent:
+    """
+    Test class component
+
+    Args:
+        msg: msg desc
+    """
+
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+
+    def build(self) -> AppDef:
+        return IGNORED
+
+
+class _TestClassComponentBadBuildReturn:
+    def build(self) -> str:
+        return "not an AppDef"
+
+
+class _TestClassComponentInheritedBuild(_TestClassComponent):
+    pass
+
+
 def current_file_path() -> str:
     return os.path.join(os.path.dirname(__file__), __file__)
 
@@ -216,6 +240,23 @@ class SpecsFileValidatorTest(unittest.TestCase):
             self._path, "_test_invalid_fn_with_varags_and_kwargs", []
         )
         self.assertEqual(0, len(linter_errors))
+
+    def test_validate_class_component(self) -> None:
+        linter_errors = validate(self._path, "_TestClassComponent")
+        self.assertListEqual([], linter_errors)
+
+    def test_validate_class_component_bad_build_return(self) -> None:
+        linter_errors = validate(self._path, "_TestClassComponentBadBuildReturn")
+        self.assertEqual(1, len(linter_errors))
+        expected_desc = (
+            "Function: build has incorrect return annotation, "
+            "supported annotation: AppDef"
+        )
+        self.assertEqual(expected_desc, linter_errors[0].description)
+
+    def test_validate_class_component_inherited_build(self) -> None:
+        linter_errors = validate(self._path, "_TestClassComponentInheritedBuild")
+        self.assertListEqual([], linter_errors)
 
     def test_validate_empty_fn(self) -> None:
         linter_errors = validate(self._path, "_test_empty_fn")

--- a/torchx/specs/test/finder_test.py
+++ b/torchx/specs/test/finder_test.py
@@ -535,6 +535,127 @@ def invalid_comp(msg) -> AppDef:
             get_component("nspkg:comp")
 
 
+class ClassComponentTest(unittest.TestCase):
+    """A class with constructor params + `build(self) -> AppDef` is a component."""
+
+    _BASE = """
+from dataclasses import dataclass
+
+
+@dataclass(kw_only=True)
+class Base:
+    image: str = "default_img"
+"""
+
+    _COMPONENT = """
+import functools
+from dataclasses import dataclass
+
+from torchx.specs import AppDef, Role
+
+from clsbase.base import Base
+
+
+@dataclass(kw_only=True)
+class ClassComp(Base):
+    \"\"\"Class component
+
+    Args:
+        image: container image
+        msg: message
+    \"\"\"
+
+    msg: str = "hello"
+
+    def build(self) -> AppDef:
+        return AppDef(
+            self.msg, roles=[Role(name="worker", image=self.image, entrypoint="echo")]
+        )
+
+
+class NoBuild:
+    \"\"\"Not a component\"\"\"
+
+
+@dataclass(kw_only=True)
+class BadBuild:
+    \"\"\"Wrong build return annotation\"\"\"
+
+    msg: str = "hello"
+
+    def build(self) -> str:
+        return self.msg
+
+
+@functools.wraps(ClassComp)
+def class_comp(**kwargs) -> AppDef:
+    return ClassComp(**kwargs).build()
+"""
+
+    def setUp(self) -> None:
+        finder._components = None
+        registry.cache_clear()
+
+        self.test_dir = Path(tempfile.mkdtemp("torchx_finder_class_component_test"))
+        pkg_dir = self.test_dir / "clsbase"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "base.py").write_text(self._BASE)
+        (pkg_dir / "comp.py").write_text(self._COMPONENT)
+        sys.path.append(str(self.test_dir))
+
+    def tearDown(self) -> None:
+        finder._components = None
+        registry.cache_clear()
+        if str(self.test_dir) in sys.path:
+            sys.path.remove(str(self.test_dir))
+        for mod in [m for m in sys.modules if m.startswith("clsbase")]:
+            del sys.modules[mod]
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_class_component_from_file(self) -> None:
+        filepath = str(self.test_dir / "clsbase" / "comp.py")
+        component = get_component(f"{filepath}:ClassComp")
+        self.assertListEqual([], component.validation_errors)
+        self.assertEqual("Class component", component.description)
+
+        from torchx.specs.builders import materialize_appdef
+
+        app = materialize_appdef(component.fn, ["--msg", "x", "--image", "img2"])
+        self.assertEqual("x", app.name)
+        self.assertEqual("img2", app.roles[0].image)
+
+    def test_class_component_inherited_field_default(self) -> None:
+        from torchx.specs.builders import materialize_appdef
+
+        component = get_component("clsbase.comp:ClassComp")
+        app = materialize_appdef(component.fn, [])
+        self.assertEqual("default_img", app.roles[0].image)
+
+    def test_class_component_from_module_path(self) -> None:
+        component = get_component("clsbase.comp.ClassComp")
+        self.assertEqual("hello", component.fn().name)
+
+    def test_class_without_build_is_invalid(self) -> None:
+        with self.assertRaisesRegex(
+            ComponentValidationException, "must define a `build"
+        ):
+            get_component("clsbase.comp:NoBuild")
+
+    def test_class_with_wrong_build_return_annotation_is_invalid(self) -> None:
+        with self.assertRaisesRegex(
+            ComponentValidationException, "incorrect return annotation"
+        ):
+            get_component("clsbase.comp:BadBuild")
+
+    def test_wrapped_class_function_pattern(self) -> None:
+        from torchx.specs.builders import materialize_appdef
+
+        component = get_component("clsbase.comp:class_comp")
+        app = materialize_appdef(component.fn, ["--msg", "y"])
+        self.assertEqual("y", app.name)
+
+
 class GetBuiltinSourceTest(unittest.TestCase):
     def setUp(self) -> None:
         # clear caches to avoid stale plugin registry state from other tests


### PR DESCRIPTION
Summary:

The finder and file linter only accepted plain functions as components, so a dataclass whose fields ARE the component's CLI args could not be run directly:

**Before**

```
$ torchx run rl/mast/train_rl.py:TrainRl --nodes=2 ...
ComponentValidationException: Component rl/mast/train_rl.py:TrainRl has
validation errors: Function TrainRl not found
```

**After**

```
$ torchx run rl/mast/train_rl.py:TrainRl --nodes=2 ...
mast_conda://torchx/train_rl-abc123
```

A class addressed as `file.py:Cls` / `pkg.module:Cls` is now a component when it implements the class-based contract: constructor params are the component's args (a dataclass's fields), and `build(self) -> AppDef` produces the app. The finder adapts it with a `functools.wraps(cls)`-carried wrapper calling `cls(*args, **kwargs).build()`, so arg parsing, `--help`, and docstring rendering see the class's own signature — the same shape genai/msl `rl/mast/{train_rl,conda_run,train}.py` hand-roll today (P1944426339), now first-class and covered by `ClassComponentTest.test_wrapped_class_function_pattern` so the hand-rolled spelling keeps working.

Linter: a matching `ClassDef` marks the component found; statically only the return annotation of a `build` defined in the class body is checked, since inherited fields/`build` live in other files the AST cannot see — a class with no `build` anywhere fails at load with an error naming the contract.

Registry enumeration (`torchx builtins`, `[torchx.components]` entrypoints) stays function-only; classes are supported for explicitly-addressed components.

Reviewed By: athmasagar

Differential Revision: D116797519
