### PR TITLE
(bugfix)[torchx][specs] Canonicalize runopt alias spellings at resolve time (#1418)

### DIFF
--- a/torchx/runner/config.py
+++ b/torchx/runner/config.py
@@ -166,7 +166,7 @@ from typing import Iterable, TextIO
 
 from torchx import settings
 from torchx.schedulers import get_scheduler_factories, Scheduler
-from torchx.specs import CfgVal, get_type_name
+from torchx.specs import CfgVal, get_type_name, InvalidRunConfigException
 from torchx.specs.api import runopt
 from torchx.util import entrypoints
 
@@ -532,29 +532,44 @@ def load(scheduler: str, f: TextIO, cfg: dict[str, CfgVal]) -> None:
 
     section = f"{scheduler}"
     if config.has_section(section):
+        seen_spelling: dict[str, tuple[str, CfgVal]] = {}
         for name, value in config.items(section):
-            if name in cfg.keys():
-                # DO NOT OVERRIDE existing configs
+            opt = runopts.get(name)
+            key = runopts.canonical_key(name) or name
+
+            if opt is None:
+                log.warning(
+                    "`%s = %s` was declared in the [%s] section"
+                    " of the config file but is not a runopt of `%s` scheduler,"
+                    " remove the entry from the config file to no longer see this warning",
+                    name,
+                    value,
+                    section,
+                    scheduler,
+                )
                 continue
 
-            if value == _NONE:
-                # should map to None (not str 'None')
-                # this also handles empty or None lists
-                cfg[name] = None
-            else:
-                opt = runopts.get(name)
+            if key not in seen_spelling and key in cfg.keys():
+                # DO NOT OVERRIDE existing configs — even file spellings
+                # that conflict with each other are moot and skip unparsed
+                continue
 
-                if opt is None:
-                    log.warning(
-                        "`%s = %s` was declared in the [%s] section"
-                        " of the config file but is not a runopt of `%s` scheduler,"
-                        " remove the entry from the config file to no longer see this warning",
-                        name,
-                        value,
-                        section,
-                        scheduler,
+            # delegate casting to the runopt itself so configfile values
+            # parse exactly like CLI `-cfg` values; `None` (str) maps to None
+            parsed: CfgVal = None if value == _NONE else opt.cast_to_type(value)
+
+            if key in seen_spelling:
+                prev_name, prev_parsed = seen_spelling[key]
+                if prev_parsed != parsed:
+                    raise InvalidRunConfigException(
+                        f"Run option `{key}` was declared in the [{section}]"
+                        f" section under two spellings (`{prev_name}` and"
+                        f" `{name}`) with conflicting values. Keep one,"
+                        f" as `{key}`",
+                        key,
+                        dict(config.items(section)),
                     )
-                else:
-                    # delegate casting to the runopt itself so configfile
-                    # values parse exactly like CLI `-cfg` values
-                    cfg[name] = opt.cast_to_type(value)
+                continue
+            seen_spelling[key] = (name, parsed)
+
+            cfg[key] = parsed

--- a/torchx/runner/test/config_test.py
+++ b/torchx/runner/test/config_test.py
@@ -31,7 +31,14 @@ from torchx.schedulers.api import (
     StructuredOpts,
 )
 from torchx.settings import ENV_TORCHXCONFIG
-from torchx.specs import AppDef, AppDryRunInfo, CfgVal, runopts, Workspace
+from torchx.specs import (
+    AppDef,
+    AppDryRunInfo,
+    CfgVal,
+    InvalidRunConfigException,
+    runopts,
+    Workspace,
+)
 from torchx.test.fixtures import TestWithTmpDir
 
 
@@ -424,6 +431,107 @@ bFalse = off
         load(scheduler="test", f=StringIO(config), cfg=cfg)
         self.assertEqual(True, cfg["bTrue"], "yes must load as True")
         self.assertEqual(False, cfg["bFalse"], "off must load as False")
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_canonicalizes_camelcase_keys(self, _) -> None:
+        """A camelCase spelling in the config file loads under the registered key."""
+        config = """#
+[test]
+lTyping = a;b
+"""
+        cfg: dict[str, CfgVal] = {}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual(["a", "b"], cfg["l_typing"])
+        self.assertNotIn("lTyping", cfg)
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_no_override_across_spellings(self, _) -> None:
+        """A cfg value under the registered key is not overridden by a
+        camelCase spelling of the same opt in the config file."""
+        config = """#
+[test]
+lTyping = a;b
+"""
+        cfg: dict[str, CfgVal] = {"l_typing": ["x"]}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual(["x"], cfg["l_typing"])
+        self.assertNotIn("lTyping", cfg)
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_conflicting_spellings_raise(self, _) -> None:
+        """Two spellings of one opt with different values must raise instead of
+        letting file order decide which value wins."""
+        config = """#
+[test]
+l_typing = a;b
+lTyping = c;d
+"""
+        with self.assertRaises(InvalidRunConfigException):
+            load(scheduler="test", f=StringIO(config), cfg={})
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_agreeing_spellings_keep_first(self, _) -> None:
+        """Two spellings of one opt with the same value load once, under the
+        registered key (mirrors `runopts.resolve` conflict semantics)."""
+        config = """#
+[test]
+l_typing = a;b
+lTyping = a;b
+"""
+        cfg: dict[str, CfgVal] = {}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual(["a", "b"], cfg["l_typing"])
+        self.assertNotIn("lTyping", cfg)
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_caller_value_moots_conflicting_spellings(self, _) -> None:
+        """A caller-supplied cfg value is never overridden, so two conflicting
+        file spellings of that opt must not raise — both file values would
+        have been discarded anyway."""
+        config = """#
+[test]
+l_typing = a;b
+lTyping = c;d
+"""
+        cfg: dict[str, CfgVal] = {"l_typing": ["x"]}
+        load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual(["x"], cfg["l_typing"], "caller-supplied value must win")
+        self.assertNotIn("lTyping", cfg)
+
+    @patch(
+        TORCHX_GET_SCHEDULER_FACTORIES,
+        return_value={"test": TestScheduler},
+    )
+    def test_load_unknown_opt_with_none_value_skipped(self, _) -> None:
+        """An unknown option is warned-and-skipped even when its value is
+        ``None`` — it must not be inserted into cfg via the None mapping."""
+        config = """#
+[test]
+unknown_opt = None
+"""
+        cfg: dict[str, CfgVal] = {}
+        with self.assertLogs("torchx.runner.config", level="WARNING") as log_ctx:
+            load(scheduler="test", f=StringIO(config), cfg=cfg)
+        self.assertEqual({}, cfg, "unknown option must not load into cfg")
+        self.assertTrue(
+            any("unknown_opt" in line for line in log_ctx.output),
+            "unknown option must emit the warn-and-skip warning",
+        )
 
     def test_no_override_load(self) -> None:
         cfg: dict[str, CfgVal] = {"log_dir": "/foo/bar", "debug": 1}

--- a/torchx/schedulers/api.py
+++ b/torchx/schedulers/api.py
@@ -33,6 +33,7 @@ from torchx.specs import (
     AppState,
     cases,
     CfgVal,
+    InvalidRunConfigException,
     NONE,
     NULL_RESOURCE,
     Role,
@@ -125,7 +126,10 @@ class StructuredOpts(Mapping[str, CfgVal]):
         """Create an instance from a raw config dict.
 
         Fields are snake_case but also accept camelCase aliases (e.g.,
-        ``hpc_identity`` can be set via ``hpcIdentity``).
+        ``hpc_identity`` can be set via ``hpcIdentity``). A field passed under
+        two spellings with conflicting values raises
+        :py:class:`~torchx.specs.InvalidRunConfigException`; equal values
+        collapse into one.
         Nested :py:class:`StructuredOpts` fields are reconstructed from
         dot-prefixed keys (e.g., ``k8s.context``).
         """
@@ -148,14 +152,24 @@ class StructuredOpts(Mapping[str, CfgVal]):
                 continue
 
             cfg_key = f.metadata.get("cfg_key", name)
-            if cfg_key in cfg:
-                kwargs[name] = cfg[cfg_key]
-            elif name in cfg:
-                kwargs[name] = cfg[name]
-            else:
-                camel_case = cases.snake_to_camel(name)
-                if camel_case in cfg:
-                    kwargs[name] = cfg[camel_case]
+            spellings = [
+                k
+                for k in dict.fromkeys((cfg_key, name, cases.snake_to_camel(name)))
+                if k in cfg
+            ]
+            if not spellings:
+                continue
+            val = cfg[spellings[0]]
+            for other in spellings[1:]:
+                if cfg[other] != val:
+                    raise InvalidRunConfigException(
+                        f"Run option `{cfg_key}` was passed under two spellings"
+                        f" (`{spellings[0]}` and `{other}`) with conflicting"
+                        f" values. Pass it once, as `{cfg_key}`",
+                        cfg_key,
+                        cfg,
+                    )
+            kwargs[name] = val
         return cls(**kwargs)
 
     # -------------------------------------------------------------------------

--- a/torchx/schedulers/test/api_test.py
+++ b/torchx/schedulers/test/api_test.py
@@ -387,15 +387,28 @@ class StructuredOptsTest(unittest.TestCase):
         self.assertEqual(opts.num_retries, 5)
         self.assertEqual(opts.enable_debug, True)
 
-    def test_from_cfg_snake_case_takes_precedence(self) -> None:
-        """Test that snake_case keys take precedence over camelCase."""
+    def test_from_cfg_conflicting_spellings_raise(self) -> None:
+        """A field passed as both snake_case and camelCase with different
+        values must raise rather than silently prefer one spelling."""
         cfg = {
             "cluster_name": "snake_value",
             "clusterName": "camel_value",
         }
+        with self.assertRaisesRegex(
+            InvalidRunConfigException, "cluster_name.*two spellings"
+        ):
+            SampleOpts.from_cfg(cfg)
+
+    def test_from_cfg_equal_spellings_collapse(self) -> None:
+        """A field passed as both snake_case and camelCase with the same
+        value collapses into the canonical field."""
+        cfg = {
+            "cluster_name": "same_value",
+            "clusterName": "same_value",
+        }
         opts = SampleOpts.from_cfg(cfg)
 
-        self.assertEqual(opts.cluster_name, "snake_value")
+        self.assertEqual(opts.cluster_name, "same_value")
 
     def test_cfg_key_metadata_alias(self) -> None:
         """Field metadata ``cfg_key`` maps external keys that cannot be

--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1165,38 +1165,59 @@ class runopts:
             else:
                 return False
 
+    def canonical_key(self, name: str) -> str | None:
+        """Returns the registered key that ``name`` spells, or ``None`` if unknown.
+
+        ``name`` may be the registered key itself or its camelCase alias
+        (e.g. ``"clusterName"`` canonicalizes to a registered ``"cluster_name"``).
+        """
+        if name in self._opts:
+            return name
+        snake = cases.camel_to_snake(name)
+        if snake != name and snake in self._opts:
+            return snake
+        return None
+
     def get(self, name: str) -> runopt | None:
         """Returns the registered option, or ``None``.
 
         Accepts camelCase names (e.g. ``"clusterName"`` resolves ``"cluster_name"``).
         """
-        # _opts maps names to runopt instances (never None), so a None
-        # result unambiguously means the key does not exist.
-        result = self._opts.get(name)
-        if result is None:
-            snake = cases.camel_to_snake(name)
-            if snake != name:
-                result = self._opts.get(snake)
-        return result
+        key = self.canonical_key(name)
+        return self._opts[key] if key is not None else None
 
     def resolve(self, cfg: Mapping[str, CfgVal]) -> dict[str, CfgVal]:
         """Validates ``cfg`` against registered options, filling defaults.
 
         Raises :py:class:`InvalidRunConfigException` for missing required options
-        or type mismatches. Accepts camelCase keys.
+        or type mismatches. Accepts camelCase aliases of registered keys and
+        canonicalizes them, so the returned cfg holds exactly one spelling per
+        option: the registered one. Passing an option under two spellings with
+        conflicting values raises :py:class:`InvalidRunConfigException`.
         """
 
-        resolved_cfg: dict[str, CfgVal] = {**cfg}
+        resolved_cfg: dict[str, CfgVal] = {}
+        given_spelling: dict[str, str] = {}  # canonical key -> spelling in cfg
+
+        for given_key, val in cfg.items():
+            cfg_key = self.canonical_key(given_key)
+            if cfg_key is None:
+                # unknown keys pass through as-is
+                resolved_cfg[given_key] = val
+                continue
+            if cfg_key in given_spelling and resolved_cfg[cfg_key] != val:
+                raise InvalidRunConfigException(
+                    f"Run option `{cfg_key}` was passed under two spellings"
+                    f" (`{given_spelling[cfg_key]}` and `{given_key}`) with"
+                    f" conflicting values. Pass it once, as `{cfg_key}`",
+                    cfg_key,
+                    cfg,
+                )
+            given_spelling.setdefault(cfg_key, given_key)
+            resolved_cfg[cfg_key] = val
 
         for cfg_key, runopt in self._opts.items():
             val = resolved_cfg.get(cfg_key)
-
-            # Fallback: try camelCase version of the registered key in cfg
-            if val is None and cfg_key not in resolved_cfg:
-                camel_key = cases.snake_to_camel(cfg_key)
-                if camel_key != cfg_key and camel_key in resolved_cfg:
-                    val = resolved_cfg.pop(camel_key)
-                    resolved_cfg[cfg_key] = val
 
             # check required opt
             if runopt.is_required and val is None:
@@ -1288,11 +1309,11 @@ class runopts:
         """
 
         cfg: dict[str, CfgVal] = {}
-        for key, val in to_dict(cfg_str).items():
-            opt = self.get(key)
-            if opt:
-                cfg[key] = opt.cast_to_type(val)
-            else:
+        given_spelling: dict[str, str] = {}
+        cfg_dict = to_dict(cfg_str)
+        for key, val in cfg_dict.items():
+            cfg_key = self.canonical_key(key)
+            if cfg_key is None:
                 logger.warning(
                     "%sunknown run option passed to scheduler: %s=%s%s",
                     YELLOW_BOLD,
@@ -1300,6 +1321,18 @@ class runopts:
                     val,
                     RESET,
                 )
+                continue
+            cast_val = self._opts[cfg_key].cast_to_type(val)
+            if cfg_key in given_spelling and cfg[cfg_key] != cast_val:
+                raise InvalidRunConfigException(
+                    f"Run option `{cfg_key}` was passed under two spellings"
+                    f" (`{given_spelling[cfg_key]}` and `{key}`) with"
+                    f" conflicting values. Pass it once, as `{cfg_key}`",
+                    cfg_key,
+                    cfg_dict,
+                )
+            given_spelling.setdefault(cfg_key, key)
+            cfg[cfg_key] = cast_val
         return cfg
 
     def cfg_from_json_repr(self, json_repr: str) -> dict[str, CfgVal]:
@@ -1307,21 +1340,34 @@ class runopts:
         Converts the given dict to a valid cfg for this ``runopts`` object.
         """
         cfg: dict[str, CfgVal] = {}
+        given_spelling: dict[str, str] = {}
         cfg_dict = json.loads(json_repr)
         for key, val in cfg_dict.items():
-            opt = self.get(key)
-            if opt:
-                # Optional runopt cfg values default their value to None,
-                # but use `_type` to specify their type when provided.
-                # Make sure not to treat None's as lists/dictionaries
-                if val is None:
-                    cfg[key] = val
-                elif opt.is_type_list_of_str:
-                    cfg[key] = [str(v) for v in val]
-                elif opt.is_type_dict_of_str:
-                    cfg[key] = {str(k): str(v) for k, v in val.items()}
-                else:
-                    cfg[key] = val
+            cfg_key = self.canonical_key(key)
+            if cfg_key is None:
+                continue
+            opt = self._opts[cfg_key]
+            # Optional runopt cfg values default their value to None,
+            # but use `_type` to specify their type when provided.
+            # Make sure not to treat None's as lists/dictionaries
+            if val is None:
+                cast_val: CfgVal = val
+            elif opt.is_type_list_of_str:
+                cast_val = [str(v) for v in val]
+            elif opt.is_type_dict_of_str:
+                cast_val = {str(k): str(v) for k, v in val.items()}
+            else:
+                cast_val = val
+            if cfg_key in given_spelling and cfg[cfg_key] != cast_val:
+                raise InvalidRunConfigException(
+                    f"Run option `{cfg_key}` was passed under two spellings"
+                    f" (`{given_spelling[cfg_key]}` and `{key}`) with"
+                    f" conflicting values. Pass it once, as `{cfg_key}`",
+                    cfg_key,
+                    cfg_dict,
+                )
+            given_spelling.setdefault(cfg_key, key)
+            cfg[cfg_key] = cast_val
         return cfg
 
     def add(

--- a/torchx/specs/test/api_test.py
+++ b/torchx/specs/test/api_test.py
@@ -1182,6 +1182,56 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual("foobar", resolved.get("run_as"))
         self.assertEqual(10, resolved.get("priority"), "default should be filled")
 
+    def test_runopts_resolve_camelcase_canonicalized(self) -> None:
+        """resolve() returns only the registered spelling, never the alias."""
+        opts = self.get_runopts()
+        resolved = opts.resolve({"runAs": "foobar", "clusterId": "c1"})
+        self.assertNotIn("runAs", resolved)
+        self.assertNotIn("clusterId", resolved)
+        self.assertEqual("foobar", resolved["run_as"])
+        self.assertEqual("c1", resolved["cluster_id"])
+
+    def test_runopts_resolve_conflicting_spellings_raise(self) -> None:
+        """resolve() raises when an opt is passed under two spellings with
+        different values instead of silently preferring one."""
+        opts = self.get_runopts()
+        with self.assertRaisesRegex(InvalidRunConfigException, "run_as.*two spellings"):
+            opts.resolve({"run_as": "alice", "runAs": "bob"})
+
+    def test_runopts_resolve_equal_spellings_collapse(self) -> None:
+        """resolve() collapses two spellings of an opt with equal values into
+        the registered spelling."""
+        opts = self.get_runopts()
+        resolved = opts.resolve({"run_as": "alice", "runAs": "alice"})
+        self.assertEqual("alice", resolved["run_as"])
+        self.assertNotIn("runAs", resolved)
+
+    def test_cfg_from_str_canonicalizes_camelcase(self) -> None:
+        """cfg_from_str() keys the parsed value by the registered spelling."""
+        opts = self.get_runopts()
+        self.assertDictEqual({"run_as": "alice"}, opts.cfg_from_str("runAs=alice"))
+
+    def test_cfg_from_str_conflicting_spellings_raise(self) -> None:
+        """cfg_from_str() raises when an opt is passed under two spellings
+        with different values."""
+        opts = self.get_runopts()
+        with self.assertRaisesRegex(InvalidRunConfigException, "run_as.*two spellings"):
+            opts.cfg_from_str("run_as=alice,runAs=bob")
+
+    def test_cfg_from_json_repr_canonicalizes_camelcase(self) -> None:
+        """cfg_from_json_repr() keys the parsed value by the registered spelling."""
+        opts = self.get_runopts()
+        self.assertDictEqual(
+            {"run_as": "alice"}, opts.cfg_from_json_repr('{"runAs": "alice"}')
+        )
+
+    def test_cfg_from_json_repr_conflicting_spellings_raise(self) -> None:
+        """cfg_from_json_repr() raises when an opt is passed under two
+        spellings with different values."""
+        opts = self.get_runopts()
+        with self.assertRaisesRegex(InvalidRunConfigException, "run_as.*two spellings"):
+            opts.cfg_from_json_repr('{"run_as": "alice", "runAs": "bob"}')
+
     def test_cfg_from_str(self) -> None:
         opts = runopts()
         opts.add("K", type_=List[str], help="a list opt", default=[])


### PR DESCRIPTION
Summary:

A run option passed under two spellings — the registered key and its camelCase alias — could silently diverge: `runopts.resolve()` left the alias in the resolved cfg whenever the registered key was also present, `cfg_from_str()`/`cfg_from_json_repr()` kept the caller's spelling, and `StructuredOpts.from_cfg` silently preferred snake_case, **so which value a scheduler read depended on which spelling it looked up**.

```
opts.resolve({"run_as": "alice", "runAs": "bob"})
```
**Before**
```
{"run_as": "alice", "runAs": "bob"}   # readers of either key see different values
```
**After**
```
InvalidRunConfigException: Run option `run_as` was passed under two spellings
(`run_as` and `runAs`) with conflicting values. Pass it once, as `run_as`
```

**This diff fixes this by** resolving aliases at parse/resolve time: `resolve()`, `cfg_from_str()`, `cfg_from_json_repr()`, `.torchxconfig` `load()`, and `StructuredOpts.from_cfg` now emit exactly one spelling per option — the registered one. Conflicting duplicate spellings raise the error above; equal ones collapse rather than error, so defensively writing both spellings with one value keeps working.

**`load()` checks unknown options and caller precedence before spellings:**

- an unknown option always warns and is skipped: `unknown_opt = None` in a config file no longer loads as `cfg["unknown_opt"] = None`
- a caller-supplied cfg value wins before the conflict check: a stale file carrying `l_typing = a;b` and `lTyping = c;d` no longer raises when the caller already passed `l_typing` — both file values would have been discarded anyway

NOTE: unknown keys still pass through `resolve()` and warn in `cfg_from_str()` — strict unknown-key validation is the next diff in this stack.

Reviewed By: athmasagar

Differential Revision: D116764224


