### PR TITLE
(docs)[torchx][specs] Document AppDryRunInfo._scheduler

### DIFF
--- a/torchx/specs/api.py
+++ b/torchx/specs/api.py
@@ -1022,6 +1022,17 @@ class AppDryRunInfo(Generic[T]):
             scheduler was handed, so mutating it in place reaches whatever the
             scheduler retained. The ``Mapping`` annotation is the only thing
             saying not to.
+        _scheduler: Name of the scheduler this ``request`` belongs to. Set on
+            the way out of :py:meth:`Runner.dryrun
+            <torchx.runner.Runner.dryrun>` and :py:meth:`Runner.describe_native
+            <torchx.runner.Runner.describe_native>`. Stays ``None`` when
+            :py:meth:`Scheduler.submit_dryrun
+            <torchx.schedulers.api.Scheduler.submit_dryrun>` or
+            :py:meth:`Scheduler.describe_native
+            <torchx.schedulers.api.Scheduler.describe_native>` is called
+            directly; :py:meth:`Runner.schedule
+            <torchx.runner.Runner.schedule>` reads it through ``none_throws``,
+            so one built that way fails there rather than at construction.
     """
 
     def __init__(self, request: T, fmt: Callable[[T], str]) -> None:


### PR DESCRIPTION
Summary:
`AppDryRunInfo._scheduler` carries the scheduler name across the
`Runner.dryrun` → `Runner.schedule` handoff, and the `Attributes:` block
documented every field except that one.

The entry now names both writers (`Runner.dryrun`, `Runner.describe_native`),
the reader (`Runner.schedule`), and the case where it stays `None`: an info
built by calling the `Scheduler` method directly, which never sets it. That
last part is what a caller cannot guess — `schedule()` puts the value through
`none_throws`, so a hand-built `AppDryRunInfo` fails there rather than at
construction.

Differential Revision: D117436297
