### PR TITLE
(bugfix)[torchx][docs] Ignore slurm.schedmd.com in linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -284,6 +284,13 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
 }
 
+# -- Options for linkcheck builder ------------------------------------------
+
+# slurm.schedmd.com recurringly times out in CI, flaking the Docs Build check.
+linkcheck_ignore = [
+    r"https://slurm\.schedmd\.com/.*",
+]
+
 # -- A patch that prevents Sphinx from cross-referencing ivar tags -------
 # See http://stackoverflow.com/a/41184353/3343043
 


### PR DESCRIPTION
Summary:
The GitHub `Docs Build / docbuild` check recurringly goes red on the sphinx `linkcheck` step: `slurm.schedmd.com` (linked from `slurm_scheduler.py` docstrings) intermittently times out, e.g. [job 97634182546](https://github.com/meta-pytorch/torchx/actions/runs/32791633993/job/97634182546). **The red check is noise** — it failed two unrelated changes on 2026-08-21 and cleared only on blind re-runs.

**This diff fixes this by** adding the domain to `linkcheck_ignore` in `docs/source/conf.py` (the config's first ignore entry), so linkcheck skips `https://slurm.schedmd.com/*` and **still checks every other external link**.

Differential Revision: D117497754
